### PR TITLE
Escape brackets with slashes rather than using HTML entities

### DIFF
--- a/iris_core/utils.js
+++ b/iris_core/utils.js
@@ -207,14 +207,17 @@ iris.sanitizeName = function (name) {
 
 iris.sanitizeEmbeds = function (html) {
 
-  html = html.split("[[[").join("&#91;&#91;&#91;");
-  html = html.split("]]]").join("&#93;&#93;&#93;");
+  if (html && typeof html === "String") {
 
-  html = html.split("{{").join("&#123;&#123;");
-  html = html.split("}}").join("&#125;&#123;");
+    html = html.split("[[[").join("/[/[/[");
+    html = html.split("]]]").join("/]/]/]");
 
-  html = html.split("{{{").join("&#123;&#123;&#123;");
-  html = html.split("}}}").join("&#125;&#125;&#125;");
+
+    html = html.split("{").join("/{");
+    html = html.split("}").join("/}");
+
+
+  }
 
   return html;
 


### PR DESCRIPTION
We used to use HTML entity encoding in the utils.js sanitizeEmbeds function. Moved this to escaping slashes instead to allow for wider use. These slashes are automatically converted back to curly brackets by the unEscape function in the frontend module. HTML encoding should be done manually if needed.
