### PR TITLE
New menu system

### DIFF
--- a/iris_core/modules/core/auth/auth.js
+++ b/iris_core/modules/core/auth/auth.js
@@ -475,6 +475,7 @@ Object.observe(iris.modules.auth.globals.userList, function (data) {
 
 iris.route.get("/logout", {
   "menu": [{
+    weight: 5,
     menuName: "admin_toolbar",
     parent: null,
     title: "Logout"

--- a/iris_core/modules/core/auth/auth.js
+++ b/iris_core/modules/core/auth/auth.js
@@ -333,7 +333,7 @@ iris.modules.auth.registerHook("hook_auth_maketoken", 0, function (thisHook, dat
         })
 
       }
-      
+
       iris.modules.auth.globals.userList[data.userid].lastActivity = Date.now();
 
       thisHook.finish(true, token);
@@ -470,6 +470,20 @@ Object.observe(iris.modules.auth.globals.userList, function (data) {
   process.send({
     sessions: iris.modules.auth.globals.userList
   });
+
+});
+
+iris.route.get("/logout", {
+  "menu": [{
+    menuName: "admin_toolbar",
+    parent: null,
+    title: "Logout"
+  }]
+}, function (req, res) {
+
+  iris.hook("hook_auth_clearauth", "root", null, req.authPass.userid);
+
+  res.send("logged out");
 
 });
 

--- a/iris_core/modules/core/menu/menu.js
+++ b/iris_core/modules/core/menu/menu.js
@@ -8,9 +8,12 @@
 
 iris.registerModule("menu");
 
-iris.modules.menu.registerHook("hook_frontend_embed__menu", 0, function (thisHook, data) {
+/**
+ * Embed function for [[[menu __]]] embeds.
+ * This is for those registered through iris.route.
+ */
 
-  // Loop over Iris routes
+iris.modules.menu.registerHook("hook_frontend_embed__menu", 0, function (thisHook, data) {
 
   var menuName = thisHook.const.embedParams[0];
 
@@ -109,332 +112,45 @@ iris.modules.menu.registerHook("hook_frontend_embed__menu", 0, function (thisHoo
 
   })
 
-  // Menu ready, check access
+  if (menuLinks.length) {
 
-  iris.modules.frontend.globals.parseTemplateFile(["menu", menuName], null, {
-    menu: menuLinks
-  }, thisHook.authPass).then(function (html) {
+    // Menu ready, check access
 
-    // Check if user can view menu
+    iris.modules.frontend.globals.parseTemplateFile(["menu", menuName], null, {
+      menu: menuLinks
+    }, thisHook.authPass).then(function (html) {
 
-    iris.hook("hook_view_menu", thisHook.authPass, menuName, menuName).then(function (access) {
+      // Check if user can view menu
 
-      thisHook.finish(true, html);
+      iris.hook("hook_view_menu", thisHook.authPass, menuName, menuName).then(function (access) {
 
-    }, function (noaccess) {
+        thisHook.finish(true, html);
 
-      thisHook.finish(false, noaccess);
+      }, function (noaccess) {
 
-    })
+        thisHook.finish(false, noaccess);
 
-  }, function (fail) {
-
-    thisHook.finish(false, fail);
-
-  })
-
-})
-
-/**
- * Get any already saved config.
- */
-
-var fs = require('fs');
-var glob = require("glob");
-
-glob(iris.configPath + "/menu/*.json", function (er, files) {
-
-  files.forEach(function (file) {
-
-    var config = fs.readFileSync(file, "utf8");
-
-    config = JSON.parse(config);
-
-    if (config.menuName) {
-
-      iris.saveConfig(config, "menu", iris.sanitizeName(config.menuName), function () {
-
-        },
-        function (fail) {
-
-          console.log(fail);
-
-        });
-    }
-  })
-
-})
-
-/**
- * Function for getting menu add/edit form.
- */
-
-iris.modules.menu.registerHook("hook_form_render_menu", 0, function (thisHook, data) {
-
-  // Check if menu name supplied and previous values available
-
-  if (thisHook.const.params[1] && thisHook.const.params[1].indexOf("{") !== -1) {
-
-    thisHook.finish(false, data);
-    return false;
-
-  } else {
-
-    iris.readConfig('menu', thisHook.const.params[1]).then(function (config) {
-
-      data.value = config;
-
-      // Create form for menus
-
-      data.schema = {
-        "menuName": {
-          "type": "text",
-          "title": "Menu title"
-        },
-        "items": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "properties": {
-              "title": {
-                "type": "text",
-                "title": "Title"
-              },
-              "path": {
-                "type": "text",
-                "title": "path"
-              },
-              "children": {
-                "type": "array",
-                "title": "Children",
-                "items": {
-                  "type": "object",
-                  "properties": {
-                    "title": {
-                      "type": "text",
-                      "title": "Title"
-                    },
-                    "path": {
-                      "type": "text",
-                      "title": "path"
-                    },
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-
-      // Hide menu title if editing
-
-      if (data.value.menuName) {
-
-        data.schema.menuName.type = "hidden";
-
-      }
-
-      thisHook.finish(true, data);
+      })
 
     }, function (fail) {
 
-      data.schema = {
-        "menuName": {
-          "type": "text",
-          "title": "Menu title"
-        },
-        "items": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "properties": {
-              "title": {
-                "type": "text",
-                "title": "Title"
-              },
-              "path": {
-                "type": "text",
-                "title": "path"
-              },
-              "children": {
-                "type": "array",
-                "title": "Children",
-                "items": {
-                  "type": "object",
-                  "properties": {
-                    "title": {
-                      "type": "text",
-                      "title": "Title"
-                    },
-                    "path": {
-                      "type": "text",
-                      "title": "path"
-                    },
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-
-      thisHook.finish(true, data);
-
-    });
-
-  }
-
-});
-
-/**
- * Form submit handler for menu add/edit form.
- */
-
-iris.modules.menu.registerHook("hook_form_submit_menu", 0, function (thisHook, data) {
-
-  // Remove blank items. TODO, this should be automatic. How come it's getting stuck?
-
-  if (thisHook.const.params.items) {
-
-    thisHook.const.params.items.forEach(function (menuitem, index) {
-
-      var item = thisHook.const.params.items[index];
-
-      if (item.children) {
-
-        item.children.forEach(function (child, childindex) {
-
-          if (!child.path || !child.title) {
-
-            item.children.splice(childindex, 1);
-
-          }
-
-        })
-
-      }
+      thisHook.finish(false, fail);
 
     })
 
-  }
+  } else {
 
-  iris.saveConfig(thisHook.const.params, "menu", iris.sanitizeName(thisHook.const.params.menuName), function () {
-
-    var data = function (res) {
-
-      res.send("/admin")
-
-    }
-
-    thisHook.finish(true, data);
-
-  }, function (fail) {
-
-    console.log(fail);
-
-  });
-
-});
-
-/* 
- * Page callback for creating a new menu.
- */
-
-iris.app.get("/admin/structure/menu/create", function (req, res) {
-
-  // If not admin, present 403 page
-
-  if (req.authPass.roles.indexOf('admin') === -1) {
-
-    iris.modules.frontend.globals.displayErrorPage(403, req, res);
-
-    return false;
+    thisHook.finish(true, "");
 
   }
 
-  iris.modules.frontend.globals.parseTemplateFile(["admin_menu_form"], ['admin_wrapper'], {}, req.authPass, req).then(function (success) {
-
-    res.send(success)
-
-  }, function (fail) {
-
-    iris.modules.frontend.globals.displayErrorPage(500, req, res);
-
-    iris.log("error", e);
-
-  });
-
-});
-
-/**
- * Page for editing an existing menu.
- */
-
-iris.app.get("/admin/structure/menu/edit/:menuName", function (req, res) {
-
-  // If not admin, present 403 page
-
-  if (req.authPass.roles.indexOf('admin') === -1) {
-
-    iris.modules.frontend.globals.displayErrorPage(403, req, res);
-
-    return false;
-
-  }
-
-  iris.modules.frontend.globals.parseTemplateFile(["admin_menu_form_edit"], ['admin_wrapper'], {
-    menuName: req.params.menuName
-  }, req.authPass, req).then(function (success) {
-
-    res.send(success)
-
-  }, function (fail) {
-
-    iris.modules.frontend.globals.displayErrorPage(500, req, res);
-
-    iris.log("error", e);
-
-  });
-
-});
-
-/**
- * List of menus page.
- * Page for editing an existing menu.
- */
-
-iris.app.get("/admin/structure/menu", function (req, res) {
-
-  // If not admin, present 403 page
-
-  if (req.authPass.roles.indexOf('admin') === -1) {
-
-    iris.modules.frontend.globals.displayErrorPage(403, req, res);
-
-    return false;
-
-  }
-
-  iris.modules.frontend.globals.parseTemplateFile(["admin_menu_list"], ['admin_wrapper'], {
-    menuList: iris.configStore["menu"]
-  }, req.authPass, req).then(function (success) {
-
-    res.send(success)
-
-  }, function (fail) {
-
-    iris.modules.frontend.globals.displayErrorPage(500, req, res);
-
-    iris.log("error", e);
-
-  });
-
-});
+})
 
 /**
  * Default menu view function.
  * Used to check permissions.
  */
+
 iris.modules.menu.registerHook("hook_view_menu", 0, function (thisHook, data) {
 
   if (thisHook.const !== "admin_toolbar") {

--- a/iris_core/modules/core/menu/menu.js
+++ b/iris_core/modules/core/menu/menu.js
@@ -8,24 +8,6 @@
 
 iris.registerModule("menu");
 
-// These should be removed as soon as admin menu links are all ported over
-
-iris.modules.menu.globals.registerMenuLink = function () {};
-iris.modules.menu.globals.registerMenu = function () {};
-
-iris.route.get("/hello", {
-  "menu": [{
-    menuName: "what",
-    parent: null,
-    path: "/about",
-    title: "Hi!"
-  }]
-}, function (req, res) {
-
-  res.send("Hello");
-
-}, 5);
-
 iris.modules.menu.registerHook("hook_frontend_embed__menu", 0, function (thisHook, data) {
 
   // Loop over Iris routes

--- a/iris_core/modules/core/menu/menu.js
+++ b/iris_core/modules/core/menu/menu.js
@@ -8,6 +8,91 @@
 
 iris.registerModule("menu");
 
+//iris.route.get("/hello", {
+//  "menu": [{
+//    menuName: "what",
+//    parent: "hi",
+//    link: "hehe",
+//    title: "heheww"
+//  }]
+//}, function (req, res) {
+//
+//  res.send("Hello");
+//
+//}, 5);
+
+iris.modules.menu.registerHook("hook_frontend_embed__menu2", 0, function (thisHook, data) {
+
+  // Loop over Iris routes
+
+  var menuName = thisHook.const.embedParams[0];
+
+  var menuItems = [];
+
+  Object.keys(iris.routes).forEach(function (path) {
+
+    if (iris.routes[path].get) {
+
+      var route = iris.routes[path].get;
+
+      if (route.options && route.options.menu && route.options.menu.length) {
+
+        // Route has a menu
+
+        route.options.menu.forEach(function (menu) {
+
+          if (menu.menuName === menuName) {
+
+            menuItems.push(menu);
+
+          }
+
+        })
+
+      }
+
+    }
+
+  })
+
+  // Generate menu
+
+  var menuLinks = [];
+
+  // Top level items first
+
+  menuItems.forEach(function (item) {
+
+    if (!item.parent) {
+
+      item.children = [];
+
+      menuLinks.push(item);
+
+    }
+
+  })
+
+  // Then parent items
+
+  // Top level items first
+
+  menuItems.forEach(function (item) {
+
+    if (item.parent) {
+
+      item.children = [];
+
+      menuLinks.push(item);
+
+    }
+
+  })
+
+  thisHook.finish(true, JSON.stringify(menuItems));
+
+})
+
 /**
  * @function registerMenuLink
  * @memberof menu

--- a/iris_core/modules/core/menu/menu.js
+++ b/iris_core/modules/core/menu/menu.js
@@ -10,21 +10,21 @@ iris.registerModule("menu");
 
 // These should be removed as soon as admin menu links are all ported over
 
-iris.modules.menu.globals.registerMenuLink = function(){};
-iris.modules.menu.globals.registerMenu = function(){};
+iris.modules.menu.globals.registerMenuLink = function () {};
+iris.modules.menu.globals.registerMenu = function () {};
 
-//iris.route.get("/hello", {
-//  "menu": [{
-//    menuName: "what",
-//    parent: null,
-//    path: "/about",
-//    title: "Hi!"
-//  }]
-//}, function (req, res) {
-//
-//  res.send("Hello");
-//
-//}, 5);
+iris.route.get("/hello", {
+  "menu": [{
+    menuName: "what",
+    parent: null,
+    path: "/about",
+    title: "Hi!"
+  }]
+}, function (req, res) {
+
+  res.send("Hello");
+
+}, 5);
 
 iris.modules.menu.registerHook("hook_frontend_embed__menu", 0, function (thisHook, data) {
 
@@ -48,6 +48,10 @@ iris.modules.menu.registerHook("hook_frontend_embed__menu", 0, function (thisHoo
 
           if (menu.menuName === menuName) {
 
+
+            if (!menu.path) {
+              menu.path = path;
+            }
             menuItems.push(menu);
 
           }
@@ -119,7 +123,7 @@ iris.modules.menu.registerHook("hook_frontend_embed__menu", 0, function (thisHoo
   }, function (fail) {
 
     thisHook.finish(false, fail);
-    
+
   })
 
 })

--- a/iris_core/modules/core/menu/menu.js
+++ b/iris_core/modules/core/menu/menu.js
@@ -30,6 +30,11 @@ iris.modules.menu.registerHook("hook_frontend_embed__menu", 0, function (thisHoo
 
           if (menu.menuName === menuName) {
 
+            if (!menu.weight) {
+
+              menu.weight = 0;
+
+            }
 
             if (!menu.path) {
               menu.path = path;
@@ -41,6 +46,26 @@ iris.modules.menu.registerHook("hook_frontend_embed__menu", 0, function (thisHoo
         })
 
       }
+
+    }
+
+  })
+
+  // Order by weight
+
+  menuItems.sort(function (a, b) {
+
+    if (a.weight < b.weight) {
+
+      return -1;
+
+    } else if (a.weight > b.weight) {
+
+      return 1;
+
+    } else {
+
+      return 0;
 
     }
 

--- a/iris_core/modules/core/menu/templates/menu.html
+++ b/iris_core/modules/core/menu/templates/menu.html
@@ -2,7 +2,7 @@
 
   <ul class="menu">
 
-    {{#menu.items}}
+    {{#menu}}
 
         <li {{#children}} class="has-children" {{/children}}>
 
@@ -25,7 +25,7 @@
       
     </li>
 
-    {{/menu.items}}
+    {{/menu}}
 
   </ul>
 

--- a/iris_core/modules/core/menu/templates/menu__admin_toolbar.html
+++ b/iris_core/modules/core/menu/templates/menu__admin_toolbar.html
@@ -3,7 +3,7 @@
 
   <ul class="menu">
     
-    {{#menu.items}}
+    {{#menu}}
     
       {{#if (iris_menu path)}}
       
@@ -33,7 +33,7 @@
     
     {{/if}}
 
-    {{/menu.items}}
+    {{/menu}}
 
   </ul>
 

--- a/iris_core/modules/core/menu/templates/menu__admin_toolbar.html
+++ b/iris_core/modules/core/menu/templates/menu__admin_toolbar.html
@@ -1,5 +1,5 @@
 <link rel="stylesheet" href="/modules/system/admin_menu.css" />
-<nav class="menu menu-{{menu.menuName}}">
+<nav class="menu menu-admin-toolbar">
 
   <ul class="menu">
     

--- a/iris_core/modules/core/system/system.js
+++ b/iris_core/modules/core/system/system.js
@@ -6,18 +6,6 @@ iris.registerModule("system");
 
 require('./system_routing.js');
 
-iris.modules.menu.globals.registerMenu("admin-toolbar");
-
-iris.modules.menu.globals.registerMenuLink("admin-toolbar", null, "/", "Home", 0);
-
-iris.modules.menu.globals.registerMenuLink("admin-toolbar", null, "/admin/structure", "Structure", 1);
-
-iris.modules.menu.globals.registerMenuLink("admin-toolbar", null, "/admin/logs", "Logs", 1);
-
-iris.modules.menu.globals.registerMenuLink("admin-toolbar", null, "/logout", "Log Out", 6);
-
-iris.modules.menu.globals.registerMenuLink("admin-toolbar", null, "/admin/restart", "Restart server", 5);
-
 iris.modules.auth.globals.registerPermission("can view admin menu", "admin");
 
 iris.modules.auth.globals.registerPermission("can access admin pages", "admin");

--- a/iris_core/modules/core/system/system_modules/modules.js
+++ b/iris_core/modules/core/system/system_modules/modules.js
@@ -30,8 +30,6 @@ iris.app.get("/admin/modules", function (req, res) {
 
 // Register menu item
 
-iris.modules.menu.globals.registerMenuLink("admin-toolbar", null, "/admin/modules", "Modules", 1);
-
 var glob = require("glob");
 var fs = require("fs");
 var path = require("path");

--- a/iris_core/modules/core/system/system_modules/modules.js
+++ b/iris_core/modules/core/system/system_modules/modules.js
@@ -1,4 +1,10 @@
-iris.app.get("/admin/modules", function (req, res) {
+iris.route.get("/admin/modules", {
+  "menu": [{
+    menuName: "admin_toolbar",
+    parent: null,
+    title: "Modules"
+  }]
+}, function (req, res) {
 
   // If not admin, present 403 page
 

--- a/iris_core/modules/core/system/system_modules/themes.js
+++ b/iris_core/modules/core/system/system_modules/themes.js
@@ -1,6 +1,12 @@
 // Register menu item
 
-iris.app.get("/admin/themes", function (req, res) {
+iris.route.get("/admin/themes", {
+  "menu": [{
+    menuName: "admin_toolbar",
+    parent: null,
+    title: "Themes"
+  }]
+}, function (req, res) {
 
   // If not admin, present 403 page
 

--- a/iris_core/modules/core/system/system_modules/themes.js
+++ b/iris_core/modules/core/system/system_modules/themes.js
@@ -1,7 +1,5 @@
 // Register menu item
 
-iris.modules.menu.globals.registerMenuLink("admin-toolbar", null, "/admin/themes", "Themes", 1);
-
 iris.app.get("/admin/themes", function (req, res) {
 
   // If not admin, present 403 page

--- a/iris_core/modules/core/system/system_routing.js
+++ b/iris_core/modules/core/system/system_routing.js
@@ -62,7 +62,13 @@ iris.app.get("/admin", function (req, res) {
 })
 
 
-iris.app.get("/admin/logs", function (req, res) {
+iris.route.get("/admin/logs", {
+  "menu": [{
+    menuName: "admin_toolbar",
+    parent: null,
+    title: "Logs"
+  }]
+}, function (req, res) {
 
   // If not admin, present 403 page
 
@@ -131,7 +137,13 @@ iris.app.get("/admin/logs", function (req, res) {
 
 // Structure page
 
-iris.app.get("/admin/structure/", function (req, res) {
+iris.route.get("/admin/structure", {
+  "menu": [{
+    menuName: "admin_toolbar",
+    parent: null,
+    title: "Structure"
+  }]
+}, function (req, res) {
 
   // If not admin, present 403 page
 
@@ -178,7 +190,13 @@ iris.app.get("/admin/structure/", function (req, res) {
 
 // Restart page
 
-iris.app.get("/admin/restart", function (req, res) {
+iris.route.get("/admin/restart", {
+  "menu": [{
+    menuName: "admin_toolbar",
+    parent: null,
+    title: "Restart"
+  }]
+}, function (req, res) {
 
   // If not admin, present 403 page
 

--- a/iris_core/modules/core/user/user.js
+++ b/iris_core/modules/core/user/user.js
@@ -10,8 +10,6 @@ iris.registerModule("user");
 
 var bcrypt = require("bcrypt-nodejs");
 
-iris.modules.menu.globals.registerMenuLink("admin-toolbar", null, "/admin/users", "Users", 1);
-
 // First ever login form
 
 iris.modules.user.registerHook("hook_form_render_set_first_user", 0, function (thisHook, data) {

--- a/iris_core/modules/core/user/user.js
+++ b/iris_core/modules/core/user/user.js
@@ -521,7 +521,7 @@ iris.modules.user.registerHook("hook_socket_connect", 0, function (thisHook, dat
 
     return cookies;
   }
-  
+
   if (cookies && cookies.userid && cookies.token) {
 
     // Check access token and userid are valid
@@ -530,8 +530,7 @@ iris.modules.user.registerHook("hook_socket_connect", 0, function (thisHook, dat
 
       iris.socketLogin(cookies.userid, cookies.token, thisHook.const.socket);
 
-    }
-    else {
+    } else {
       thisHook.finish(false);
     }
 
@@ -571,7 +570,13 @@ iris.app.post("/api/login", function (req, res) {
 });
 
 
-iris.app.get("/admin/users", function (req, res) {
+iris.route.get("/admin/users", {
+  "menu": [{
+    menuName: "admin_toolbar",
+    parent: null,
+    title: "Users"
+  }]
+}, function (req, res) {
 
   if (iris.modules.entityUI) {
 

--- a/iris_core/modules/extra/blocks/blocks.js
+++ b/iris_core/modules/extra/blocks/blocks.js
@@ -348,11 +348,11 @@ iris.modules.blocks.registerHook("hook_form_render", 0, function (thisHook, data
       type: "hidden",
       default: formTitle.split("_")[1]
     };
-    
+
     data.schema.contents = {
-      type : "ckeditor",
-      title : "Contents",
-      required : true
+      type: "ckeditor",
+      title: "Contents",
+      required: true
     }
 
     // Check if a config file has already been saved for this block. If so, load in the current settings.
@@ -383,23 +383,23 @@ iris.modules.blocks.registerHook("hook_form_render", 0, function (thisHook, data
 
 iris.modules.blocks.registerHook("hook_form_render_blockDeleteForm", 0, function (thisHook, data) {
 
-    if (!data.schema) {
+  if (!data.schema) {
 
-      data.schema = {};
+    data.schema = {};
 
-    }
+  }
 
-    data.schema["blockTitle"] = {
-      type: "hidden",
-      default: thisHook.const.params[2]
-    };
+  data.schema["blockTitle"] = {
+    type: "hidden",
+    default: thisHook.const.params[2]
+  };
 
-    data.schema["blockType"] = {
-      type: "hidden",
-      default: thisHook.const.params[1]
-    };
+  data.schema["blockType"] = {
+    type: "hidden",
+    default: thisHook.const.params[1]
+  };
 
-    thisHook.finish(true, data);
+  thisHook.finish(true, data);
 
 });
 
@@ -417,7 +417,7 @@ iris.modules.blocks.registerHook("hook_form_submit_blockDeleteForm", 0, function
 
   }
 
-  iris.deleteConfig("blocks/" + thisHook.const.params.blockType, iris.sanitizeName(thisHook.const.params.blockTitle), function(err) {
+  iris.deleteConfig("blocks/" + thisHook.const.params.blockType, iris.sanitizeName(thisHook.const.params.blockTitle), function (err) {
 
     if (err) {
 
@@ -477,7 +477,13 @@ iris.modules.blocks.registerHook("hook_form_submit", 0, function (thisHook, data
 
 // Admin page routing handler
 
-iris.app.get("/admin/blocks", function (req, res) {
+iris.route.get("/admin/blocks", {
+  "menu": [{
+    menuName: "admin_toolbar",
+    parent: "/admin/structure",
+    title: "Blocks"
+  }]
+}, function (req, res) {
 
   // If not admin, present 403 page
 

--- a/iris_core/modules/extra/blocks/blocks.js
+++ b/iris_core/modules/extra/blocks/blocks.js
@@ -6,10 +6,6 @@
  * @namespace blocks
  */
 
-// Register menu item
-
-iris.modules.menu.globals.registerMenuLink("admin-toolbar", "/admin/structure", "/admin/blocks", "Blocks", 1);
-
 /**
  * @member blockTypes
  * @memberof blocks

--- a/iris_core/modules/extra/configUI/configUI.js
+++ b/iris_core/modules/extra/configUI/configUI.js
@@ -26,8 +26,25 @@ iris.app.get("/admin/api/config/import", function (req, res) {
 
 });
 
+iris.route.get("/admin/config", {
+  "menu": [{
+    menuName: "admin_toolbar",
+    parent: null,
+    title: "Config"
+  }]
+}, function (req, res) {
+  
+  res.send("Config top level to go here.")
+  
+});
 
-iris.app.get("/admin/config/export", function (req, res) {
+iris.route.get("/admin/config/export", {
+  "menu": [{
+    menuName: "admin_toolbar",
+    parent: "/admin/config",
+    title: "Config export"
+  }]
+}, function (req, res) {
 
   // If not admin, present 403 page
 
@@ -53,7 +70,13 @@ iris.app.get("/admin/config/export", function (req, res) {
 
 });
 
-iris.app.get("/admin/config/import", function (req, res) {
+iris.route.get("/admin/config/import", {
+  "menu": [{
+    menuName: "admin_toolbar",
+    parent: "/admin/config",
+    title: "Config import"
+  }]
+}, function (req, res) {
 
   // If not admin, present 403 page
 
@@ -125,7 +148,13 @@ iris.app.get("/admin/config/diff", function (req, res) {
 
 // Config page
 
-iris.app.get("/admin/config/", function (req, res) {
+iris.route.get("/admin/config", {
+  "menu": [{
+    menuName: "admin_toolbar",
+    parent: null,
+    title: "Config"
+  }]
+}, function (req, res) {
 
   // Get list of config clashes
 
@@ -252,4 +281,3 @@ var showConfigDiff = function (callback) {
   callback(output);
 
 }
-

--- a/iris_core/modules/extra/configUI/configUI.js
+++ b/iris_core/modules/extra/configUI/configUI.js
@@ -4,11 +4,6 @@
 
 var ncp = require('ncp').ncp;
 
-iris.modules.menu.globals.registerMenuLink("admin-toolbar", null, "/admin/config", "Config", 1);
-
-
-iris.modules.menu.globals.registerMenuLink("admin-toolbar", "/admin/config", "/admin/config/export", "Export config", 1);
-iris.modules.menu.globals.registerMenuLink("admin-toolbar", "/admin/config", "/admin/config/import", "Import config", 1);
 iris.app.get("/admin/api/config/export", function (req, res) {
 
   ncp(iris.configPath, iris.sitePath + "/staging", function (err) {

--- a/iris_core/modules/extra/entityUI/schemaUI.js
+++ b/iris_core/modules/extra/entityUI/schemaUI.js
@@ -1,7 +1,13 @@
 var path = require('path');
 
 
-iris.app.get("/admin/structure/entities", function (req, res) {
+iris.route.get("/admin/structure/entities", {
+  "menu": [{
+    menuName: "admin_toolbar",
+    parent: "/admin/structure",
+    title: "Entities"
+  }]
+}, function (req, res) {
 
   // If not admin, present 403 page
 

--- a/iris_core/modules/extra/entityUI/schemaUI.js
+++ b/iris_core/modules/extra/entityUI/schemaUI.js
@@ -1,7 +1,5 @@
 var path = require('path');
 
-iris.modules.menu.globals.registerMenuLink("admin-toolbar", "/admin/structure", "/admin/structure/entities", "Entities", 1);
-
 
 iris.app.get("/admin/structure/entities", function (req, res) {
 

--- a/iris_core/modules/extra/menu_ui/menu_ui.iris.module
+++ b/iris_core/modules/extra/menu_ui/menu_ui.iris.module
@@ -1,0 +1,3 @@
+{
+  "name": "Menu UI"
+}

--- a/iris_core/modules/extra/menu_ui/menu_ui.js
+++ b/iris_core/modules/extra/menu_ui/menu_ui.js
@@ -1,0 +1,313 @@
+/**
+ * Embed for [[[menu __]]] menus made using the UI.
+ */
+
+iris.modules.menu_ui.registerHook("hook_frontend_embed__menu", 2, function (thisHook, data) {
+
+  var menuName = thisHook.const.embedParams[0];
+
+  iris.readConfig('menu', menuName).then(function (config) {
+
+    iris.modules.frontend.globals.parseTemplateFile(["menu", menuName], null, {
+      menu: config.items
+    }, thisHook.authPass).then(function (html) {
+
+      // Check if user can view menu
+
+      iris.hook("hook_view_menu", thisHook.authPass, menuName, menuName).then(function (access) {
+
+        thisHook.finish(true, html);
+
+      }, function (noaccess) {
+
+        thisHook.finish(false, noaccess);
+
+      })
+
+    }, function (fail) {
+
+      thisHook.finish(false, fail);
+
+    })
+
+  }, function (fail) {
+
+    thisHook.finish(true, data);
+
+  });
+
+})
+
+/**
+ * Function for getting menu add/edit form.
+ */
+
+iris.modules.menu_ui.registerHook("hook_form_render_menu", 0, function (thisHook, data) {
+
+  // Check if menu name supplied and previous values available
+
+  if (thisHook.const.params[1] && thisHook.const.params[1].indexOf("{") !== -1) {
+
+    thisHook.finish(false, data);
+    return false;
+
+  } else {
+
+    iris.readConfig('menu', thisHook.const.params[1]).then(function (config) {
+
+      data.value = config;
+
+      // Create form for menus
+
+      data.schema = {
+        "menuName": {
+          "type": "text",
+          "title": "Menu title"
+        },
+        "items": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "title": {
+                "type": "text",
+                "title": "Title"
+              },
+              "path": {
+                "type": "text",
+                "title": "path"
+              },
+              "children": {
+                "type": "array",
+                "title": "Children",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "title": {
+                      "type": "text",
+                      "title": "Title"
+                    },
+                    "path": {
+                      "type": "text",
+                      "title": "path"
+                    },
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+
+      // Hide menu title if editing
+
+      if (data.value.menuName) {
+
+        data.schema.menuName.type = "hidden";
+
+      }
+
+      thisHook.finish(true, data);
+
+    }, function (fail) {
+
+      data.schema = {
+        "menuName": {
+          "type": "text",
+          "title": "Menu title"
+        },
+        "items": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "title": {
+                "type": "text",
+                "title": "Title"
+              },
+              "path": {
+                "type": "text",
+                "title": "path"
+              },
+              "children": {
+                "type": "array",
+                "title": "Children",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "title": {
+                      "type": "text",
+                      "title": "Title"
+                    },
+                    "path": {
+                      "type": "text",
+                      "title": "path"
+                    },
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+
+      thisHook.finish(true, data);
+
+    });
+
+  }
+
+});
+
+/**
+ * Form submit handler for menu add/edit form.
+ */
+
+iris.modules.menu_ui.registerHook("hook_form_submit_menu", 0, function (thisHook, data) {
+
+  // Remove blank items. TODO, this should be automatic. How come it's getting stuck?
+
+  if (thisHook.const.params.items) {
+
+    thisHook.const.params.items.forEach(function (menuitem, index) {
+
+      var item = thisHook.const.params.items[index];
+
+      if (item.children) {
+
+        item.children.forEach(function (child, childindex) {
+
+          if (!child.path || !child.title) {
+
+            item.children.splice(childindex, 1);
+
+          }
+
+        })
+
+      }
+
+    })
+
+  }
+
+  iris.saveConfig(thisHook.const.params, "menu", iris.sanitizeName(thisHook.const.params.menuName), function () {
+
+    var data = function (res) {
+
+      res.json({
+        redirect: "/admin"
+      });
+
+    }
+
+    thisHook.finish(true, data);
+
+  }, function (fail) {
+
+    console.log(fail);
+
+  });
+
+});
+
+/* 
+ * Page callback for creating a new menu.
+ */
+
+iris.app.get("/admin/structure/menu/create", function (req, res) {
+
+  // If not admin, present 403 page
+
+  if (req.authPass.roles.indexOf('admin') === -1) {
+
+    iris.modules.frontend.globals.displayErrorPage(403, req, res);
+
+    return false;
+
+  }
+
+  iris.modules.frontend.globals.parseTemplateFile(["admin_menu_form"], ['admin_wrapper'], {}, req.authPass, req).then(function (success) {
+
+    res.send(success)
+
+  }, function (fail) {
+
+    iris.modules.frontend.globals.displayErrorPage(500, req, res);
+
+    iris.log("error", e);
+
+  });
+
+});
+
+/**
+ * Page for editing an existing menu.
+ */
+
+iris.app.get("/admin/structure/menu/edit/:menuName", function (req, res) {
+
+  // If not admin, present 403 page
+
+  if (req.authPass.roles.indexOf('admin') === -1) {
+
+    iris.modules.frontend.globals.displayErrorPage(403, req, res);
+
+    return false;
+
+  }
+
+  iris.modules.frontend.globals.parseTemplateFile(["admin_menu_form_edit"], ['admin_wrapper'], {
+    menuName: req.params.menuName
+  }, req.authPass, req).then(function (success) {
+
+    res.send(success)
+
+  }, function (fail) {
+
+    iris.modules.frontend.globals.displayErrorPage(500, req, res);
+
+    iris.log("error", e);
+
+  });
+
+});
+
+/**
+ * List of menus page.
+ * Page for editing an existing menu.
+ */
+
+iris.route.get("/admin/structure/menu", {
+  "menu": [{
+    menuName: "admin_toolbar",
+    parent: "/admin/structure",
+    title: "Menu"
+  }]
+}, function (req, res) {
+
+  // If not admin, present 403 page
+
+  if (req.authPass.roles.indexOf('admin') === -1) {
+
+    iris.modules.frontend.globals.displayErrorPage(403, req, res);
+
+    return false;
+
+  }
+
+  iris.modules.frontend.globals.parseTemplateFile(["admin_menu_list"], ['admin_wrapper'], {
+    menuList: iris.configStore["menu"]
+  }, req.authPass, req).then(function (success) {
+
+    res.send(success)
+
+  }, function (fail) {
+
+    iris.modules.frontend.globals.displayErrorPage(500, req, res);
+
+    iris.log("error", e);
+
+  });
+
+});

--- a/iris_core/modules/extra/permissionsUI/permissionsUI.js
+++ b/iris_core/modules/extra/permissionsUI/permissionsUI.js
@@ -3,8 +3,6 @@
  */
 var fs = require('fs');
 
-iris.modules.menu.globals.registerMenuLink("admin-toolbar", "/admin/users", "/admin/users/permissions", "Permissions", 1);
-
 // Permissions form
 
 iris.modules.permissionsUI.registerHook("hook_form_render_permissions", 0, function (thisHook, data) {

--- a/iris_core/modules/extra/permissionsUI/permissionsUI.js
+++ b/iris_core/modules/extra/permissionsUI/permissionsUI.js
@@ -113,7 +113,13 @@ iris.modules.permissionsUI.registerHook("hook_form_submit_permissions", 0, funct
 });
 
 
-iris.app.get("/admin/users/permissions", function (req, res) {
+iris.route.get("/admin/users/permissions", {
+  "menu": [{
+    menuName: "admin_toolbar",
+    parent: "/admin/users",
+    title: "Permissions"
+  }]
+}, function (req, res) {
 
   // If not admin, present 403 page
 

--- a/iris_core/modules/extra/regions/regions.js
+++ b/iris_core/modules/extra/regions/regions.js
@@ -6,7 +6,7 @@ iris.modules.forms.registerHook("hook_form_render_regions", 0, function (thisHoo
 
   var blocks = [];
 
- Object.keys(iris.modules.blocks.globals.blocks).forEach(function (blockType) {
+  Object.keys(iris.modules.blocks.globals.blocks).forEach(function (blockType) {
 
     Object.keys(iris.modules.blocks.globals.blocks[blockType]).forEach(function (block) {
 
@@ -283,7 +283,13 @@ iris.modules.regions.registerHook("hook_block_render", 0, function (thisHook, da
 
 // Regions admin system
 
-iris.app.get("/admin/regions", function (req, res) {
+iris.route.get("/admin/regions", {
+  "menu": [{
+    menuName: "admin_toolbar",
+    parent: "/admin/structure",
+    title: "Regions"
+  }]
+}, function (req, res) {
 
   // If not admin, present 403 page
 

--- a/iris_core/modules/extra/regions/regions.js
+++ b/iris_core/modules/extra/regions/regions.js
@@ -1,16 +1,12 @@
 var fs = require('fs');
 
-// Register menu item
-
-iris.modules.menu.globals.registerMenuLink("admin-toolbar", "/admin/structure", "/admin/regions", "Regions", 1);
-
 iris.modules.forms.registerHook("hook_form_render_regions", 0, function (thisHook, data) {
 
   // Loop over available block types and add their blocks to a list for the form
 
   var blocks = [];
 
-  Object.keys(iris.modules.blocks.globals.blocks).forEach(function (blockType) {
+ Object.keys(iris.modules.blocks.globals.blocks).forEach(function (blockType) {
 
     Object.keys(iris.modules.blocks.globals.blocks[blockType]).forEach(function (block) {
 

--- a/iris_core/modules/extra/roles_ui/roles_ui.js
+++ b/iris_core/modules/extra/roles_ui/roles_ui.js
@@ -22,11 +22,9 @@ iris.readConfig('auth', 'auth_roles').then(function (config) {
 
 });
 
-iris.modules.menu.globals.registerMenuLink("admin-toolbar", "/admin/users", "/admin/users/roles", "Roles", 0);
-
 iris.app.get("/admin/users", function (req, res) {
 
-  iris.modules.system.globals.listEntities(req, res, 'user');
+ iris.modules.system.globals.listEntities(req, res, 'user');
 
 });
 

--- a/iris_core/modules/extra/roles_ui/roles_ui.js
+++ b/iris_core/modules/extra/roles_ui/roles_ui.js
@@ -1,4 +1,3 @@
-
 iris.readConfig('auth', 'auth_roles').then(function (config) {
 
   // config is now accessible as a standard JavaScript object
@@ -24,11 +23,17 @@ iris.readConfig('auth', 'auth_roles').then(function (config) {
 
 iris.app.get("/admin/users", function (req, res) {
 
- iris.modules.system.globals.listEntities(req, res, 'user');
+  iris.modules.system.globals.listEntities(req, res, 'user');
 
 });
 
-iris.app.get("/admin/users/roles", function (req, res) {
+iris.route.get("/admin/users/roles", {
+  "menu": [{
+    menuName: "admin_toolbar",
+    parent: "/admin/users",
+    title: "Roles"
+  }]
+}, function (req, res) {
 
   // If not admin, present 403 page
 

--- a/iris_core/modules/extra/textfilters/textfilters.js
+++ b/iris_core/modules/extra/textfilters/textfilters.js
@@ -109,7 +109,13 @@ iris.modules.textfilters.registerHook("hook_form_submit_textformat", 0, function
 
 })
 
-iris.app.get("/admin/textfilters", function (req, res) {
+iris.app.get("/admin/textfilters", {
+  "menu": [{
+    menuName: "admin_toolbar",
+    parent: null,
+    title: "Textfilters"
+  }]
+}, function (req, res) {
 
   // If not admin, present 403 page
 

--- a/iris_core/modules/extra/textfilters/textfilters.js
+++ b/iris_core/modules/extra/textfilters/textfilters.js
@@ -294,8 +294,6 @@ iris.modules.textfilters.registerHook("hook_schemafield_render", 0, function (th
 
 });
 
-iris.modules.menu.globals.registerMenuLink("admin-toolbar", null, "/admin/textfilters", "Text filters");
-
 var sanitizeHtml = require('sanitize-html');
 
 iris.modules.textfilters.registerHook("hook_entity_presave", 0, function (thisHook, data) {

--- a/iris_core/modules/extra/triggers/triggers.js
+++ b/iris_core/modules/extra/triggers/triggers.js
@@ -527,7 +527,13 @@ iris.app.get("/admin/triggers/edit/:action", function (req, res) {
 
 // Main actions landing page
 
-iris.app.get("/admin/triggers", function (req, res) {
+iris.app.get("/admin/triggers", {
+  "menu": [{
+    menuName: "admin_toolbar",
+    parent: null,
+    title: "Triggers"
+  }]
+}, function (req, res) {
 
   // If not admin, present 403 page
 

--- a/iris_core/modules/extra/triggers/triggers.js
+++ b/iris_core/modules/extra/triggers/triggers.js
@@ -525,8 +525,6 @@ iris.app.get("/admin/triggers/edit/:action", function (req, res) {
 
 })
 
-iris.modules.menu.globals.registerMenuLink("admin-toolbar", null, "/admin/triggers", "Triggers", 1);
-
 // Main actions landing page
 
 iris.app.get("/admin/triggers", function (req, res) {

--- a/oldmenus.js
+++ b/oldmenus.js
@@ -1,1 +1,0 @@
-//iris.modules.menu.globals.registerMenuLink("admin-toolbar", null, "/", "Home", 0);

--- a/oldmenus.js
+++ b/oldmenus.js
@@ -1,0 +1,1 @@
+//iris.modules.menu.globals.registerMenuLink("admin-toolbar", null, "/", "Home", 0);


### PR DESCRIPTION
Menus now use hook_frontend_embed__ and are split into two categories:

First defined using iris.route , these are system/module registered menus.

Second is through the UI using a now optional menu_ui module. This process is the same as before.
