### PR TITLE
Hide entitytypename field when editing schema

### DIFF
--- a/iris_core/modules/extra/entityUI/schemaUI.js
+++ b/iris_core/modules/extra/entityUI/schemaUI.js
@@ -914,6 +914,12 @@ iris.modules.entityUI.registerHook("hook_form_render_schema", 0, function (thisH
     }
   }
 
+  if (entityType) {
+
+    data.schema.entityTypeName.type = "hidden";
+
+  }
+
   thisHook.finish(true, data);
 
 });


### PR DESCRIPTION
Entity type name should not be changeable after first submit as it's tied to the actual database collection.
