### PR TITLE
Fix configstore delete

### DIFF
--- a/iris_core/config.js
+++ b/iris_core/config.js
@@ -91,8 +91,10 @@ iris.deleteConfig = function (directory, filename, callback) {
 
   } else {
 
-    delete iris.configStore[directory][filename];
-
+    if (iris.configStore[directory]) {
+      delete iris.configStore[directory][filename];
+    }
+    
   }
 
   var filePath = path.join(iris.sitePath, "/configurations", directory);


### PR DESCRIPTION
Empty config in memory was triggering error if you tried to delete it. Wrapped in conditional.
