### PR TITLE
Menu no access bug fix

### DIFF
--- a/iris_core/modules/core/menu/menu.js
+++ b/iris_core/modules/core/menu/menu.js
@@ -111,7 +111,7 @@ iris.modules.menu.registerHook("hook_frontend_embed__menu", 0, function (thisHoo
     }
 
   })
-
+  
   if (menuLinks.length) {
 
     // Menu ready, check access
@@ -128,7 +128,7 @@ iris.modules.menu.registerHook("hook_frontend_embed__menu", 0, function (thisHoo
 
       }, function (noaccess) {
 
-        thisHook.finish(false, noaccess);
+        thisHook.finish(true, "");
 
       })
 


### PR DESCRIPTION
If a user couldn't view a menu it was timing out. Hook should finish true and empty, not false. Fixed.
