### PR TITLE
Bug when no parameters passed to parsetemplatefile

### DIFF
--- a/iris_core/modules/core/frontend/frontend.js
+++ b/iris_core/modules/core/frontend/frontend.js
@@ -1071,6 +1071,12 @@ var insertTags = function (html, vars) {
  */
 iris.modules.frontend.globals.parseTemplateFile = function (templateName, wrapperTemplateName, parameters, authPass, req) {
 
+  if (!parameters) {
+
+    parameters = {};
+
+  }
+
   if (req) {
 
     parameters.req = req;


### PR DESCRIPTION
Sometimes parseTemplateFile is called with no parameters (such as the admin/modules page). In this case the parameters.req block fails. Set a default parameters object in this case.
