### PR TITLE
Allow empty field settings - fix bug where this broke form

### DIFF
--- a/iris_core/modules/extra/entityUI/schemaUI.js
+++ b/iris_core/modules/extra/entityUI/schemaUI.js
@@ -1378,7 +1378,7 @@ iris.modules.entityUI.registerHook("hook_form_render_schemafieldwidgets", 0, fun
         "helpvalue": "No widgets available for this field"
         }
     ];
-    iris.log("error", "No widget defined for field: " + fieldTypeName);
+
     thisHook.finish(true, data);
     return false;
 

--- a/iris_core/modules/extra/entityUI/schemaUI.js
+++ b/iris_core/modules/extra/entityUI/schemaUI.js
@@ -1076,7 +1076,11 @@ iris.modules.entityUI.registerHook("hook_form_render_schemafield", 0, function (
       data
     ).then(function (form) {
 
-      form.form.push("settings");
+      if (form.schema.settings) {
+
+        form.form.push("settings");
+
+      }
 
       form.form.push({
         "type": "submit",


### PR DESCRIPTION
Fields without field-specific settings (file at the moment for example, though this should change) weren't showing the basic field settings as it was looking for a settings object where one didn't exist and was breaking the form. Caught this.
