### PR TITLE
Bugfix - paths of other entity types being deleted when eids clash

### DIFF
--- a/iris_core/modules/core/paths/paths.js
+++ b/iris_core/modules/core/paths/paths.js
@@ -118,7 +118,7 @@ iris.modules.paths.registerHook("hook_entity_updated", 0, function (thisHook, da
 
     var currentPath = iris.modules.paths.globals.entityPaths[path];
 
-    if (currentPath.eid.toString() === data.eid.toString()) {
+    if ((currentPath.eid.toString() === data.eid.toString()) && (currentPath.entityType === data.entityType)) {
 
       delete iris.modules.paths.globals.entityPaths[path];
 


### PR DESCRIPTION
Using a path for two different entity types and saving an entity with the same eid as another (entity ids are entity type level not global) was deleting an unrelated path.
