### PR TITLE
Form load order

### DIFF
--- a/iris_core/modules/core/forms/forms.js
+++ b/iris_core/modules/core/forms/forms.js
@@ -311,6 +311,12 @@ iris.modules.forms.registerHook("hook_frontend_embed__form", 0, function (thisHo
     rank: 1
   }
 
+    type: "script",
+    attributes: {
+      "src": "/modules/forms/clientforms.js"
+    },
+  }
+
   //
 
   var formParams = thisHook.context.embedParams;
@@ -398,11 +404,11 @@ iris.modules.forms.registerHook("hook_frontend_embed__form", 0, function (thisHo
 
       var output = "";
 
-      var uniqueId = formName + Date.now().toString();
+      var uniqueId = formName + token;
 
       output += "<form data-params=" + formParams + " method='POST' data-formid='" + formName + "' id='" + uniqueId + "' ng-non-bindable ></form> \n";
 
-      output += "<script>$('#" + uniqueId + "').jsonForm(" + toSource(form) + ");</script>";
+      output += "<script>iris.forms['" + uniqueId + "'] = " + toSource(form) + "</script>";
 
       callback(output);
 

--- a/iris_core/modules/core/forms/forms.js
+++ b/iris_core/modules/core/forms/forms.js
@@ -311,10 +311,12 @@ iris.modules.forms.registerHook("hook_frontend_embed__form", 0, function (thisHo
     rank: 1
   }
 
+  variables.tags.headTags["clientforms"] = {
     type: "script",
     attributes: {
       "src": "/modules/forms/clientforms.js"
     },
+    rank: 4
   }
 
   //
@@ -398,8 +400,6 @@ iris.modules.forms.registerHook("hook_frontend_embed__form", 0, function (thisHo
 
         form.value.formid = formName;
         form.value.formToken = token;
-        form.value.formToken = token;
-
       }
 
       var output = "";

--- a/iris_core/modules/core/forms/static/clientforms.js
+++ b/iris_core/modules/core/forms/static/clientforms.js
@@ -1,0 +1,11 @@
+iris.forms = {};
+
+$(document).on("ready", function () {
+
+  Object.keys(iris.forms).forEach(function (form) {
+        
+    $("#"+form).jsonForm(iris.forms[form]);
+
+  })
+
+})


### PR DESCRIPTION
HTML ID attribute for forms is now based on the form token (timestamp was not good enough as it was loading them simultaniously). 

Loading of JSONform now happens on document ready in a new file called clientforms.js to stop issue where forms were being loaded out of sync. Now they're all initialised at once when the page is ready.
