### PR TITLE
Autopath module for auto-generated token path

### DIFF
--- a/iris_core/modules/extra/autopath/autopath.iris.module
+++ b/iris_core/modules/extra/autopath/autopath.iris.module
@@ -1,0 +1,4 @@
+{
+  "name": "Autopath",
+  "description": "Allows for automatically generated entity type paths based on fields on the entity."
+}

--- a/iris_core/modules/extra/autopath/autopath.js
+++ b/iris_core/modules/extra/autopath/autopath.js
@@ -1,0 +1,197 @@
+/**
+ * Register permission for editing autopath settings.
+ */
+
+iris.modules.auth.globals.registerPermission("can adminster autopath", "paths");
+
+/**
+ * Create route for autopath administration page.
+ */
+
+iris.route.get("/admin/structure/autopath", {
+  permissions: ["can administer autopath"],
+  "menu": [{
+    menuName: "admin_toolbar",
+    parent: "/admin/structure",
+    title: "Autopath"
+  }]
+}, function (req, res) {
+
+  // Push in all entity types that have a path field
+
+  var entityTypes = [];
+
+  Object.keys(iris.dbSchemaConfig).forEach(function (entityType) {
+
+    if (iris.dbSchemaConfig[entityType].fields && iris.dbSchemaConfig[entityType].fields.path) {
+
+      entityTypes.push(entityType);
+
+    }
+
+  })
+
+  iris.modules.frontend.globals.parseTemplateFile(["admin_autopath"], ['admin_wrapper'], {
+    entityTypes: entityTypes
+  }, req.authPass, req).then(function (success) {
+
+    res.send(success)
+
+  }, function (fail) {
+
+    iris.modules.frontend.globals.displayErrorPage(500, req, res);
+
+    iris.log("error", fail);
+
+  });
+
+})
+
+/**
+ * Register autopath settings form (admin page shows one for each entity type). 
+ * Implements hook_form_render
+ */
+
+iris.modules.autopath.registerHook("hook_form_render__autopath", 0, function (thisHook, data) {
+
+  var entityType = thisHook.context.params[1];
+
+  var tokens = [];
+
+  Object.keys(iris.dbSchemaConfig[entityType].fields).forEach(function (fieldName) {
+
+    var type = iris.dbSchema[entityType][fieldName].type;
+
+    if (type === String) {
+
+      tokens.push("[" + fieldName + "]");
+
+    }
+
+  })
+
+  var render = function (savedPattern) {
+
+    data.schema.entityType = {
+
+      "type": "hidden",
+      "default": entityType
+
+    }
+
+    data.schema.pattern = {
+
+      "type": "text",
+      "title": "Path pattern",
+      "description": "Fill in a path, you may include any of the following tokens to substitute field values from the entity itself. <br /> Available tokens: <b>" + tokens.join(" ") + "</b>",
+
+    }
+
+    if (savedPattern) {
+
+      data.schema.pattern.default = savedPattern;
+
+    }
+
+    thisHook.pass(data);
+
+  }
+
+  iris.readConfig("autopath", entityType).then(function (savedPattern) {
+
+    render(savedPattern)
+
+  }, function (fail) {
+
+    render();
+
+  });
+
+})
+
+/**
+ * Register autopath settings form submit handler to save config. 
+ * Implements hook_form_submit
+ */
+
+iris.modules.autopath.registerHook("hook_form_submit__autopath", 0, function (thisHook, data) {
+
+  if (thisHook.context.params.pattern[0] !== "/") {
+
+    thisHook.context.params.pattern = "/" + thisHook.context.params.pattern;
+
+  }
+
+  iris.saveConfig(thisHook.context.params.pattern, "autopath", thisHook.context.params.entityType, function () {
+
+    thisHook.pass(data);
+
+  })
+
+
+});
+
+/**
+ * Add helper description to entity edit forms with a path. 
+ * Implements hook_form_render
+ */
+
+iris.modules.autopath.registerHook("hook_form_render__entity", 2, function (thisHook, data) {
+
+  if (data.schema && data.schema.path) {
+
+    if (!data.schema.path.description) {
+
+      data.schema.path.description = "";
+
+    }
+
+    data.schema.path.description = data.schema.path.description + "Leave empty or clear to set path automatically based on autopath settings."
+
+    thisHook.pass(data);
+
+  };
+
+});
+
+/**
+ * Save path using autopath template if available and path is left empty (swap out [token] values) 
+ * Implements hook_entity_presave
+ */
+
+iris.modules.autopath.registerHook("hook_entity_presave", 2, function (thisHook, data) {
+
+  if ((!data.path || !data.path.length) && iris.dbSchemaConfig[data.entityType].fields.path) {
+
+    iris.readConfig("autopath", data.entityType).then(function (savedPattern) {
+
+        Object.keys(data).forEach(function (field) {
+
+          if (savedPattern.indexOf("[" + field + "]") !== -1) {
+
+            var value = iris.sanitizeName(data[field]).split("_").join("-");
+
+            savedPattern = savedPattern.split("[" + field + "]").join(value);
+
+          }
+
+        })
+
+        data.path = savedPattern;
+
+        thisHook.pass(data);
+
+      },
+      function (fail) {
+
+        thisHook.pass(data);
+
+      });
+
+  } else {
+
+    thisHook.pass(data);
+
+  }
+
+});

--- a/iris_core/modules/extra/autopath/templates/admin_autopath.html
+++ b/iris_core/modules/extra/autopath/templates/admin_autopath.html
@@ -1,0 +1,9 @@
+<h1>Autopath</h1> 
+
+{{#each entityTypes}} 
+
+<h2>{{this}}</h2>
+
+  [[[form autopath,{{this}}]]] 
+
+{{/each}}


### PR DESCRIPTION
Allows for tokenised url paths to be generated for an entity based on text fields for that entity.

e.g a blog path that doesn't need a path written out for it each time but is based on its title. Paths can simply be overriden by typing in a value for the path field.

`[fieldName]` is swapped out for a url friendly version of that field if the path is left blank.

An admin form in the structure menu allows for creating of token substitutions and offers list of tokens based on textfields of that entity type. Only shows entities if they have  a `path` field.
