### PR TITLE
fix(form): Completion handler for form renderes

### DIFF
--- a/iris_core/modules/core/forms/forms.js
+++ b/iris_core/modules/core/forms/forms.js
@@ -405,10 +405,9 @@ iris.modules.forms.registerHook("hook_frontend_embed__form", 0, function (thisHo
       var output = "";
 
       var uniqueId = formName + token;
+      output += "<form data-params='" + formParams + "' method='POST' data-formid='" + formName + "' id='" + uniqueId + "' ng-non-bindable ></form> \n";
 
-      output += "<form data-params=" + formParams + " method='POST' data-formid='" + formName + "' id='" + uniqueId + "' ng-non-bindable ></form> \n";
-
-      output += "<script>iris.forms['" + uniqueId + "'] = " + toSource(form) + "</script>";
+      output += "<script>iris.forms['" + uniqueId + "'] = { form: " + toSource(form) + ", onComplete: 'formComplete_" + formName + "'}</script>";
 
       callback(output);
 

--- a/iris_core/modules/core/forms/static/clientforms.js
+++ b/iris_core/modules/core/forms/static/clientforms.js
@@ -1,11 +1,12 @@
 iris.forms = {};
 
 $(document).on("ready", function () {
-
   Object.keys(iris.forms).forEach(function (form) {
-        
-    $("#"+form).jsonForm(iris.forms[form]);
-
+    $("#"+form).jsonForm(iris.forms[form].form);
+    var tmpFunc = new Function(iris.forms[form].onComplete + "()");
+    if (typeof window[iris.forms[form].onComplete] == 'function') {
+      tmpFunc();
+    }
   })
 
-})
+});


### PR DESCRIPTION
Was an issue that form getting data run before they were rendered by JSONForm.

New featuer:
If doing stuff on a form as soon as it is rendered, there will be a new function that can be used:

formComplete_formName()

Attach this to the window of the site on the front end.

I.e.

window.formComplete_SignInForm = function(){
    init()
}

Signed-off-by: Alex Bor alexhbor@gmail.com
