### PR TITLE
Integrate i18n into Iris

### DIFF
--- a/iris_core/modules/core/auth/auth.js
+++ b/iris_core/modules/core/auth/auth.js
@@ -263,6 +263,23 @@ iris.modules.auth.registerHook("hook_auth_authpass", 0, function (thisHook, data
 
   }
 
+  // This is required to add i18n to the authPass object. This allows each user to have a separate language set for
+  // their request. It's an alternative to passing the req object everywhere.
+  // Translated text can be achieved by thisHook.authPass.t('Text to translate');
+  // To change the users language, use hook_auth_authpass and then thisHook.authPass.setLocale([language code]);
+  if (thisHook.req.headers['accept-language']) {
+
+    data.headers = {'accept-language' : thisHook.req.headers['accept-language']};
+
+  }
+  else {
+
+    data.headers = {'accept-language' : 'en-US,en'};
+
+  }
+
+  iris.i18n.init(data);
+
   thisHook.pass(data);
 
 });

--- a/iris_core/server.js
+++ b/iris_core/server.js
@@ -2,7 +2,8 @@
  * @file Express HTTP server setup and management functions.
  */
 var express = require('express'),
-  bodyParser = require('body-parser');
+  bodyParser = require('body-parser'),
+  i18n = require("i18n");
 
 iris.app = express();
 
@@ -15,6 +16,20 @@ iris.app.use(bodyParser.urlencoded({
   parameterLimit: 10000,
   limit: 10485760
 }));
+
+// I18n.
+
+i18n.configure({
+  defaultLocale: 'en',
+  autoReload: true,
+  directory: iris.configPath + '/locales',
+  api: {
+    '__' : 't',
+    '__n' : 'tn'
+  }
+});
+
+iris.i18n = i18n;
 
 var cookieParser = require('cookie-parser')
 iris.app.use(cookieParser());

--- a/iris_core/server.js
+++ b/iris_core/server.js
@@ -3,7 +3,8 @@
  */
 var express = require('express'),
   bodyParser = require('body-parser'),
-  i18n = require("i18n");
+  i18n = require("i18n"),
+  fs = require("fs");
 
 iris.app = express();
 
@@ -18,7 +19,9 @@ iris.app.use(bodyParser.urlencoded({
 }));
 
 // I18n.
-
+if (!fs.existsSync(iris.configPath + '/locales')){
+  fs.mkdirSync(iris.configPath + '/locales');
+}
 i18n.configure({
   defaultLocale: 'en',
   autoReload: true,

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "express": "^4.13.3",
     "glob": "^5.0.15",
     "handlebars": "^4.0.4",
+    "i18n": "^0.8.1",
     "merge": "^1.2.0",
     "minimatch": "^3.0.0",
     "mkdirp": "^0.5.1",
@@ -26,7 +27,8 @@
     "prettydiff": "^1.16.6",
     "sanitize-html": "^1.10.0",
     "socket.io": "^1.2.1",
-    "tosource": "^1.0.0"
+    "tosource": "^1.0.0",
+    "i18n": "^0.8.1"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
A new library has been added as a dependency, so npm install (or npm update?) will be required.

To test, in your code where ever authPass is available:

```
var string = req/thisHook.authPass.t('My string');
```

string should = 'My string'

The language defaults to en, so check in /configurations/locals for a file en.js

This should contain something like {'My string' : 'My string'}

To test translating from one language to another, create a de.js file in /locals and add:

```
{
    "My string": "German string"
}
```

Then in your function do:

```
var ap = thisHook.authPass;
// Change the language for this user. This would typically be done in hook_auth_authpass
ap.setLocale('de');

var string = ap.t('My string');
```

string should now = 'German string'

For more info on how to do more complicated translations, consult https://github.com/mashpie/i18n-node
