### PR TITLE
fix(forms): Rendering forms

### DIFF
--- a/iris_core/modules/core/forms/forms.js
+++ b/iris_core/modules/core/forms/forms.js
@@ -249,7 +249,7 @@ iris.route.get("/modules/forms/extrafields.js", function (req, res) {
 
     output += "iris.forms['" + field + "'] = " + iris.modules.forms.globals.widgets[field] + "()\n" + "\n";
 
-  })
+  });
 
   res.setHeader('content-type', 'application/javascript');
   res.send(output);
@@ -407,7 +407,8 @@ iris.modules.forms.registerHook("hook_frontend_embed__form", 0, function (thisHo
       var uniqueId = formName + token;
       output += "<form data-params='" + formParams + "' method='POST' data-formid='" + formName + "' id='" + uniqueId + "' ng-non-bindable ></form> \n";
 
-      output += "<script>iris.forms['" + uniqueId + "'] = { form: " + toSource(form) + ", onComplete: 'formComplete_" + formName + "'}</script>";
+      output += "<script>iris.forms['" + uniqueId + "'] = { form: " + toSource(form) + ", onComplete: 'formComplete_" + formName + "'}" +
+        "\n if(typeof iris.forms.renderForm == \"function\") iris.forms.renderForm('" + uniqueId + "');</script>";
 
       callback(output);
 

--- a/iris_core/modules/core/forms/static/clientforms.js
+++ b/iris_core/modules/core/forms/static/clientforms.js
@@ -1,12 +1,23 @@
 iris.forms = {};
 
 $(document).on("ready", function () {
-  Object.keys(iris.forms).forEach(function (form) {
-    $("#"+form).jsonForm(iris.forms[form].form);
-    var tmpFunc = new Function(iris.forms[form].onComplete + "()");
-    if (typeof window[iris.forms[form].onComplete] == 'function') {
-      tmpFunc();
+  iris.forms.cache = [];
+
+  iris.forms.renderForm = function(formId){
+    if(iris.forms.cache.indexOf(formId) > -1) return;
+    $("#"+formId).jsonForm(iris.forms[formId].form);
+    var onComplete = new Function(iris.forms[formId].onComplete + "()");
+    if (typeof window[iris.forms[formId].onComplete] == 'function') {
+      onComplete();
     }
+    iris.forms.cache.push(formId);
+  }
+
+  Object.keys(iris.forms).forEach(function (form) {
+    iris.forms.renderForm(form);
   })
+
+
+
 
 });


### PR DESCRIPTION
Was more form issues, forms that get loaded in won't render.

Fix:
On page load, "iris.forms.renderForm" isn't a function, so nothing will happen. But on page load, all forms get rendered and their callback methods will run.

After page load, iris.forms.renderForm(formId) will exist, all new loaded forms will run this method to render.

iris.forms frontend keeps a cache of rendered forms so will not render the same form twice.

Signed-off-by: Alex Bor alexhbor@gmail.com
