### PR TITLE
Permissions callback

### DIFF
--- a/iris_core/modules/core/auth/auth.js
+++ b/iris_core/modules/core/auth/auth.js
@@ -539,12 +539,24 @@ iris.modules.auth.registerHook("hook_request_intercept", 0, function (thisHook, 
 
   // Check if a matching route is found
 
-  if (thisHook.context.req.irisRoute && thisHook.context.req.irisRoute.options && thisHook.context.req.irisRoute.options.permissions) {
+  if (thisHook.context.req.irisRoute && thisHook.context.req.irisRoute.options && (thisHook.context.req.irisRoute.options.permissions || thisHook.context.req.irisRoute.options.permissionsCallback)) {
 
-    var permissions = thisHook.context.req.irisRoute.options.permissions;
+    if (thisHook.context.req.irisRoute.options.permissionsCallback) {
 
-    var access = iris.modules.auth.globals.checkPermissions(permissions, thisHook.context.req.authPass);
+      if (typeof thisHook.context.req.irisRoute.options.permissionsCallback == 'function') {
 
+        var access = thisHook.context.req.irisRoute.options.permissionsCallback(thisHook.context.req.irisRoute.options, thisHook.authPass);
+
+      }
+
+    }
+    else {
+
+      var permissions = thisHook.context.req.irisRoute.options.permissions;
+
+      var access = iris.modules.auth.globals.checkPermissions(permissions, thisHook.context.req.authPass);
+
+    }
     if (!access) {
 
       iris.invokeHook("hook_display_error_page", thisHook.context.req.authPass, {

--- a/iris_core/modules/core/auth/auth.js
+++ b/iris_core/modules/core/auth/auth.js
@@ -539,24 +539,8 @@ iris.modules.auth.registerHook("hook_request_intercept", 0, function (thisHook, 
 
   // Check if a matching route is found
 
-  if (thisHook.context.req.irisRoute && thisHook.context.req.irisRoute.options && (thisHook.context.req.irisRoute.options.permissions || thisHook.context.req.irisRoute.options.permissionsCallback)) {
+  var actOnResult = function(access) {
 
-    if (thisHook.context.req.irisRoute.options.permissionsCallback) {
-
-      if (typeof thisHook.context.req.irisRoute.options.permissionsCallback == 'function') {
-
-        var access = thisHook.context.req.irisRoute.options.permissionsCallback(thisHook.context.req.irisRoute.options, thisHook.authPass);
-
-      }
-
-    }
-    else {
-
-      var permissions = thisHook.context.req.irisRoute.options.permissions;
-
-      var access = iris.modules.auth.globals.checkPermissions(permissions, thisHook.context.req.authPass);
-
-    }
     if (!access) {
 
       iris.invokeHook("hook_display_error_page", thisHook.context.req.authPass, {
@@ -581,6 +565,25 @@ iris.modules.auth.registerHook("hook_request_intercept", 0, function (thisHook, 
       thisHook.pass(data);
 
     }
+
+  };
+
+  if (thisHook.context.req.irisRoute && thisHook.context.req.irisRoute.options && thisHook.context.req.irisRoute.options.permissionsCallback) {
+
+    if (typeof thisHook.context.req.irisRoute.options.permissionsCallback == 'function') {
+
+      thisHook.context.req.irisRoute.options.permissionsCallback(thisHook.context.req, actOnResult);
+
+    }
+
+  }
+  else if (thisHook.context.req.irisRoute && thisHook.context.req.irisRoute.options && thisHook.context.req.irisRoute.options.permissions) {
+
+    var permissions = thisHook.context.req.irisRoute.options.permissions;
+
+    var access = iris.modules.auth.globals.checkPermissions(permissions, thisHook.context.req.authPass);
+
+    actOnResult(access);
 
   } else {
 

--- a/iris_core/modules/core/forms/forms.js
+++ b/iris_core/modules/core/forms/forms.js
@@ -532,7 +532,7 @@ iris.modules.forms.registerHook("hook_frontend_embed__form", 0, function (thisHo
 
     }, function (fail) {
 
-      if (fail = "No such hook exists") {
+      if (fail == "No such hook exists") {
 
         renderForm(formTemplate, function (output) {
 


### PR DESCRIPTION
This extends the iris routes so now you can add logic to page permissions.

use case:

There is an entity type where you want certain users (not entity authors) to edit specific entities based on some requirement, ie, they are listed as a manager of that entity.

When defining the route options for that callback you add 'permissionsCallback' and provide a function as the value.

The function needs to be defined before the route as below:

```
iris.modules.entityUI.globals.permissionsCallback = function(options, authPath) {

  \\ Some logic here
  return false;

}

var routes = {
  'edit': {
    "title": "Edit entity",
    "permissions": ["can create custom reports"],
    "permissionsCallback": iris.modules.entityUI.globals.permissionsCallback
  }
};
```

'permissionsCallback' is not required so should not be a breaking change.
