### PR TITLE
Improve form error handling

### DIFF
--- a/iris_core/modules/core/forms/forms.js
+++ b/iris_core/modules/core/forms/forms.js
@@ -47,7 +47,18 @@ iris.modules.forms.registerHook("hook_catch_request", 0, function (thisHook, dat
           });
         });
 
-      } else {
+      }
+      else if (data.errors && data.errors.length > 0) {
+
+        thisHook.pass(function (res) {
+
+          res.json({
+            errors: data.errors
+          });
+
+        });
+      }
+      else {
         // If no callback is supplied provide a basic redirect to the same page
         var callback = function (res) {
 

--- a/iris_core/modules/extra/entityUI/entityUI.js
+++ b/iris_core/modules/extra/entityUI/entityUI.js
@@ -503,23 +503,29 @@ iris.modules.entityUI.registerHook("hook_form_submit__entity", 0, function (this
 
       iris.invokeHook(hook, thisHook.authPass, finalValues, finalValues).then(function (success) {
 
-        thisHook.pass(function (res) {
-
-          res.send({
-            redirect: "/admin/structure/entities"
-          })
-
-        });
+        data.callback = "/admin/structure/entities";
+        thisHook.pass(data);
 
       }, function (fail) {
 
-        thisHook.pass(function (res) {
+        var msg = thisHook.authPass.t("Error saving entity");
 
-          res.send({
-            errors: JSON.stringify(fail)
-          });
+        if (fail.errmsg) {
 
+          msg = fail.errmsg;
+
+        }
+        else {
+
+          msg = JSON.stringify(fail);
+          
+        }
+        data.errors.push({
+          'message' : msg
         });
+
+        iris.log("error", msg);
+        thisHook.pass(data);
 
       });
 


### PR DESCRIPTION
If an error occurs in mongo saving an entity, it was spitting out dozens of 'undefined' error messages on the client form.

Obviously, this is not very useful.

I've updated it so that it will show the actual error message returned from mongo.
