### PR TITLE
Recursively adds 'form' attributes to fields within fieldsets

### DIFF
--- a/modules/core/entity/entity_fetch.js
+++ b/modules/core/entity/entity_fetch.js
@@ -104,6 +104,18 @@ iris.modules.entity.registerHook("hook_entity_fetch", 0, function (thisHook, fet
 
       }
 
+      if (fieldQuery.operator.toLowerCase().indexOf("regex") !== -1) {
+
+        var queryItem = {};
+
+        queryItem[fieldQuery["field"]] = {
+          $regex: fieldQuery.value
+        };
+
+        query.$and.push(queryItem);
+
+      }
+
       if (fieldQuery.operator.toLowerCase().indexOf("includes") !== -1) {
 
         var queryItem = {};

--- a/modules/core/entity/entity_fetch.js
+++ b/modules/core/entity/entity_fetch.js
@@ -104,18 +104,6 @@ iris.modules.entity.registerHook("hook_entity_fetch", 0, function (thisHook, fet
 
       }
 
-      if (fieldQuery.operator.toLowerCase().indexOf("regex") !== -1) {
-
-        var queryItem = {};
-
-        queryItem[fieldQuery["field"]] = {
-          $regex: fieldQuery.value
-        };
-
-        query.$and.push(queryItem);
-
-      }
-
       if (fieldQuery.operator.toLowerCase().indexOf("includes") !== -1) {
 
         var queryItem = {};

--- a/modules/extra/entityUI/schemaUI.js
+++ b/modules/extra/entityUI/schemaUI.js
@@ -327,13 +327,11 @@ iris.modules.entityUI.globals.widgetForm = function(type, field, parent, req, re
 iris.route.get("/admin/schema/:type/fields/:field/delete", routes.fieldDelete, function (req, res) {
 
   // Render admin_schema_field template.
+  req.irisRoute.options.title = req.authPass.t('Delete field {{field}} on entity type {{type}}', {field: req.params.field, type: req.params.type});
 
   iris.modules.frontend.globals.parseTemplateFile(["admin_schema_field_delete"], ['admin_wrapper'], {
-
     entityType: req.params.type,
-
     field: req.params.field,
-
   }, req.authPass, req).then(function (success) {
 
 

--- a/modules/extra/entityUI/schemaUI.js
+++ b/modules/extra/entityUI/schemaUI.js
@@ -863,7 +863,7 @@ iris.modules.entityUI.registerHook("hook_form_submit__schemaFieldListing", 0, fu
       var redirect = '/admin/schema/' + entityType;
 
       if (thisHook.context.params.machineName != '') {
-        redirect += '/' + thisHook.context.params.machineName;
+        redirect += '/fields/' + thisHook.context.params.machineName;
       } else {
         if (parent != '') {
           redirect += '/fieldset/' + parent;
@@ -1195,7 +1195,7 @@ iris.modules.entityUI.registerHook("hook_form_render__schemafield", 0, function 
         data
       ).then(function (form) {
 
-        if (form.schema.settings) {
+        if (form.schema.settings && !form.settingsOverride) {
 
           form.form.push("settings");
 

--- a/modules/extra/entityUI/templates/admin_schema_field_delete.html
+++ b/modules/extra/entityUI/templates/admin_schema_field_delete.html
@@ -1,4 +1,4 @@
-<h1>Delete field {{field}} on entity type {{entityType}}</h1>
+
 
 [[[form schemafieldDelete,{{entityType}},{{field}}]]]
 


### PR DESCRIPTION
I also added a form.settingsOverride flag to be used in hook_form_render__field_settings__[fieldname]

If you add 

```
form.settingsOverride = true;
```

To the hook above, it will prevent the system from automatically adding

```
form.form.push("settings");
```

I needed this as in my hook I was added the settings to 'form' array as an object, such as:

```
 data.form.push({
      "key": "settings." + schema,
      "htmlClass" : "choose-fields " + extraClass
    });
```

Overriding 'form.form.push("settings");' means the fields wont be added twice.

I also added a 'regex' operator the entity queries so now you can do more complex searching.
