### PR TITLE
jsonform patch

### DIFF
--- a/modules/core/forms/static/jsonform/lib/jsonform.js
+++ b/modules/core/forms/static/jsonform/lib/jsonform.js
@@ -2861,7 +2861,7 @@ formNode.prototype.computeInitialValues = function (values, ignoreDefaultValues,
               // Note applying the array path probably doesn't make any sense,
               // but some geek might want to have a label "foo[].bar[].baz",
               // with the [] replaced by the appropriate array path.
-              this.value = applyArrayPath(this.value, this.arrayPath);
+              //this.value = applyArrayPath(this.value, this.arrayPath);
             }
             if (this.value) {
               this.value = _template(this.value, formData, valueTemplateSettings);


### PR DESCRIPTION
I have created an issue on the jsonform project to fix a bug. Essentially, if you have nested fields with values that contains '[1]' or any other number or even just '[]' i think, it alters the value from say:

sometext[1] to sometext[0]

This is a clear bug as it shouldn't be altering field values at all.

I have commented out the problem line from jsonform until the actual jsonform file gets updated

https://github.com/ulion/jsonform/issues/31
