### PR TITLE
Allow objects in field type definitions

### DIFF
--- a/db.js
+++ b/db.js
@@ -214,6 +214,32 @@ iris.dbPopulate = function() {
       case "[Date]":
         return [Date];
     }
+    
+     // May be a more complex field
+
+    if (typeof type === "object") {
+
+      var typeObject = {};
+
+      Object.keys(type).forEach(function (key) {
+
+        var processedtype = typeConverter(type[key]);
+
+        if (processedtype) {
+
+          typeObject[key] = processedtype;
+
+        }
+
+      })
+      
+      return mongoose.Schema(typeObject);
+      
+    } else {
+
+      return false;
+
+    }
 
     return false;
 

--- a/modules/extra/entityUI/entityUI.js
+++ b/modules/extra/entityUI/entityUI.js
@@ -239,10 +239,19 @@ iris.modules.entityUI.registerHook("hook_form_render__entity", 0, function (this
     var getFieldForm = function (field, callback, currentValue, fieldName) {
 
       var fieldType = field.fieldType;
+      var fieldTypeType;
+
+      try {
+
+        fieldTypeType = iris.fieldTypes[fieldType].type;
+
+      } catch (e) {
+
+        fieldTypeType = field.type
+
+      }
 
       if (fieldType !== "Fieldset") {
-
-        var fieldTypeType = iris.fieldTypes[fieldType].type;
 
         // Check if a widget has been set for the field
 
@@ -314,7 +323,45 @@ iris.modules.entityUI.registerHook("hook_form_render__entity", 0, function (this
                 fieldSettings: field
               }).then(function (form) {
 
-                callback(form);
+                if (form) {
+
+                  callback(form);
+
+                } else {
+
+                  // Might be a custom complex field type
+
+                  if (typeof fieldTypeType === "object") {
+
+                    var form = {
+                      type: "object",
+                      title: fieldName,
+                      properties: {}
+                    }
+
+                    Object.keys(iris.fieldTypes[fieldType].type).forEach(function (nested) {
+
+                      form.properties[nested] = {
+                        title: nested,
+                        default: currentValue ? currentValue[nested] : null
+                      }
+
+                      switch (iris.fieldTypes[fieldType].type[nested]) {
+                        case "String":
+                          form.properties[nested].type = "text"
+                          break;
+                        case "Number":
+                          form.properties[nested].type = "number"
+                          break;
+                      }
+
+                    })
+
+                    callback(form);
+
+                  }
+
+                }
 
               }, function (fail) {
 


### PR DESCRIPTION
Example:

``` JSON

{
"name": "Image",
"type": {"title":"String","alt":"String","path":"String"}
}

```

Normal field form hooks run for entityUI but it also has a default of simply showing an object with fields of the type given.

Currently only supports String and Number for the default form handler. More complex ones can be added in `entityUI.js` if this is shown to be a good solution.
