### PR TITLE
Entity revision system + ui (plus entityLinks helper)

### DIFF
--- a/modules/extra/entityUI/entityUI.js
+++ b/modules/extra/entityUI/entityUI.js
@@ -834,6 +834,51 @@ iris.modules.entityUI.registerHook("hook_form_submit__entity", 0, function (this
 
 });
 
+
+/**
+ * @member hook_frontend_entity_links
+ * @memberof entityUI
+ *
+ * @desc uses thisHook.context.entity to add to linkList, an array of the form [{title:...,link:...}] used for an entity's administrative links
+ *
+ */
+
+iris.modules.entityUI.registerHook("hook_entity_links", 0, function (thisHook, linkList) {
+
+  thisHook.pass(linkList);
+
+});
+
+/**
+ * @member hook_entity_view
+ * @memberof entityUI
+ *
+ * @desc Runs entity view through hook_entity_links to add any administrative links for the entity
+ *
+ */
+
+iris.modules.entityUI.registerHook("hook_entity_view", 0, function (thisHook, entity) {
+
+  if (entity) {
+
+    iris.invokeHook("hook_entity_links", thisHook.authPass, {
+      entity: entity
+    }, []).then(function (linkList) {
+
+      entity.links = linkList;
+
+      thisHook.pass(entity);
+
+    })
+
+  } else {
+
+    thisHook.pass(entity);
+
+  }
+
+})
+
 // List of entities
 
 iris.route.get("/admin/entitylist/:type", function (req, res) {
@@ -851,6 +896,8 @@ iris.route.get("/admin/entitylist/:type", function (req, res) {
   iris.invokeHook("hook_entity_fetch", req.authPass, null, {
     entities: [req.params.type]
   }).then(function (result) {
+
+    // Get entity links
 
     iris.modules.frontend.globals.parseTemplateFile(["admin_entitylist"], ['admin_wrapper'], {
       type: req.params.type,

--- a/modules/extra/entityUI/templates/admin_entitylist.html
+++ b/modules/extra/entityUI/templates/admin_entitylist.html
@@ -1,8 +1,5 @@
 <!--<h1>List of {{type}} entities</h1> -->
 
-<p>
-</p>
-
 <table class="table" id="entity-list">
   
   <tbody>
@@ -17,9 +14,17 @@
       <td>{{#if path}}<a href="{{path}}">{{eid}}</a>{{else}}{{eid}}{{/if}}</td>
       <td>{{#if path}}<a href="{{path}}">{{username}}{{title}}</a>{{else}}{{username}}{{title}}{{/if}}</td>
       <td><a class="btn btn-default" href="/{{ entityType }}/{{ eid }}/edit">Edit</a> &nbsp;
-        <a class="btn btn-danger" href="/{{ entityType }}/{{ eid }}/delete">Delete</a></td>
+        <a class="btn btn-danger" href="/{{ entityType }}/{{ eid }}/delete">Delete</a>
+      
+        {{#each links}}
+      
+          <a class="btn btn-default" href="{{link}}">{{title}}</a>
+      
+        {{/each}}
+
+      </td>
     </tr>
-    
+      
     {{/each}}
 
   </tbody>

--- a/modules/extra/revisions/revisions.iris.module
+++ b/modules/extra/revisions/revisions.iris.module
@@ -1,0 +1,5 @@
+{
+  "name": "Revisions",
+  "description": "Entity revisions system",
+  "weight": 1
+}

--- a/modules/extra/revisions/revisions.js
+++ b/modules/extra/revisions/revisions.js
@@ -126,26 +126,26 @@ iris.modules.revisions.globals.getRevision = function (entityType, eid, revision
 
                 } else {
 
-                  reject();
+                  reject(403);
 
                 }
 
               }, function (fail) {
 
-                reject();
+                reject(403);
 
               });
 
             }, function (fail) {
 
-              reject();
+              reject(403);
 
             })
 
 
           } else {
 
-            reject()
+            reject(400)
 
           }
 
@@ -153,7 +153,7 @@ iris.modules.revisions.globals.getRevision = function (entityType, eid, revision
 
       } else {
 
-        reject();
+        reject(400);
 
       }
 
@@ -230,7 +230,26 @@ iris.route.get("/revisions/:type/:eid/:back", function (req, res) {
 
   }, function (fail) {
 
-    res.status(400).send(fail);
+    if (!isNaN(fail)) {
+
+      iris.invokeHook("hook_display_error_page", req.authPass, {
+        error: fail,
+        req: req
+      }).then(function (success) {
+
+        res.send(success);
+
+      }, function (fail) {
+
+        res.status(fail).send(fail);
+
+      });
+
+    } else {
+
+      res.status(400).send(fail);
+
+    }
 
   })
 

--- a/modules/extra/revisions/revisions.js
+++ b/modules/extra/revisions/revisions.js
@@ -210,7 +210,13 @@ iris.route.get("/revisions/:type/:eid/:back", function (req, res) {
 
     }
 
-    // Add button to revert
+    // Add revert button if not the current revision
+
+    if (parseInt(req.params.back) === parseInt(revision.total) - 1) {
+
+      message += " | <a href=/revisions/" + req.params.type + "/" + req.params.eid + "/" + req.params.back.toString() + "/revert" + ">Revert to this revision</a>";
+
+    }
 
     iris.message(req.authPass.userid, message, "info");
 

--- a/modules/extra/revisions/revisions.js
+++ b/modules/extra/revisions/revisions.js
@@ -91,6 +91,12 @@ iris.modules.revisions.globals.getRevision = function (entityType, eid, revision
 
             var i;
 
+            if (revisionID === "current") {
+
+              revisionID = revisions.length;
+
+            }
+
             if (revisionID > revisions.length) {
 
               reject("no such revision");
@@ -178,6 +184,12 @@ iris.route.get("/revisions/:type/:eid/:back", function (req, res) {
 
     }
 
+    if (req.params.back === "current") {
+
+      req.params.back = revision.total;
+
+    }
+
     var message = "";
 
     if (parseInt(req.params.back) !== 0) {
@@ -212,7 +224,7 @@ iris.route.get("/revisions/:type/:eid/:back", function (req, res) {
 
     // Add revert button if not the current revision
 
-    if (parseInt(req.params.back) === parseInt(revision.total) - 1) {
+    if (parseInt(req.params.back) !== parseInt(revision.total)) {
 
       message += " | <a href=/revisions/" + req.params.type + "/" + req.params.eid + "/" + req.params.back.toString() + "/revert" + ">Revert to this revision</a>";
 
@@ -337,5 +349,24 @@ iris.route.get("/revisions/:entityType/:eid/:revision/revert", function (req, re
     res.send(html);
 
   });
+
+});
+
+/**
+ * @member hook_frontend_entity_links
+ * @memberof revisions
+ *
+ * @desc add links to view entity revisions
+ *
+ */
+
+iris.modules.revisions.registerHook("hook_entity_links", 0, function (thisHook, linkList) {
+
+  linkList.push({
+    link: "/revisions/" + thisHook.context.entity.entityType + "/" + thisHook.context.entity.eid + "/" + "current",
+    title: "Revisions"
+  })
+
+  thisHook.pass(linkList);
 
 });

--- a/modules/extra/revisions/revisions.js
+++ b/modules/extra/revisions/revisions.js
@@ -159,7 +159,7 @@ iris.modules.revisions.globals.getRevision = function (entityType, eid, revision
 
       } else {
 
-        reject(400);
+        reject(404);
 
       }
 

--- a/modules/extra/revisions/revisions.js
+++ b/modules/extra/revisions/revisions.js
@@ -112,7 +112,18 @@ iris.route.get("/revisions/:type/:eid/:back", function (req, res) {
 
           }
 
-          res.send(patched);
+          iris.modules.frontend.globals.parseTemplateFile([patched.entityType, patched.eid], ["html", patched.entityType, patched.eid], {current:patched}, req.authPass, req).then(function (success) {
+
+            res.send(success);
+
+          }, function (fail) {
+
+            iris.log("error", fail);
+
+            res.status(500).send(fail);
+
+          });
+
 
         } else {
 

--- a/modules/extra/revisions/revisions.js
+++ b/modules/extra/revisions/revisions.js
@@ -1,0 +1,60 @@
+var jsondiffpatch = require('jsondiffpatch').create();
+
+// Initialise database collections for revisions
+
+process.on("dbReady", function () {
+
+  iris.modules.revisions.globals.collections = {};
+
+  var collections = Object.keys(iris.dbCollections);
+
+  collections.forEach(function (collection) {
+
+    var schema = new mongoose.Schema({
+      eid: {
+        type: Number
+      },
+      revisions: {
+        type: [{
+          date: Date,
+          diff: mongoose.Schema.Types.Mixed
+        }]
+      }
+    });
+
+    iris.modules.revisions.globals.collections[collection] = mongoose.model("revisions_" + collection, schema);
+
+  })
+
+});
+
+iris.modules.revisions.registerHook("hook_entity_updated", 0, function (thisHook, data) {
+
+  var previous = thisHook.context.previous;
+  var current = thisHook.context.new;
+
+  // Create diff
+
+  var diff = jsondiffpatch.diff(previous, current);
+
+  var revisions = iris.modules.revisions.globals.collections[current.entityType];
+
+  revisions.findOneAndUpdate({
+    "eid": current.eid
+  }, {
+    $push: {
+      "revisions": {
+        date: Date.now(),
+        diff: diff
+      }
+    }
+  }, {
+    new: true,
+    upsert: true
+  }, function (err, doc) {
+
+    thisHook.pass(data);
+
+  });
+
+});

--- a/modules/extra/revisions/revisions.js
+++ b/modules/extra/revisions/revisions.js
@@ -104,15 +104,56 @@ iris.route.get("/revisions/:type/:eid/:back", function (req, res) {
 
           }
 
+
           var patched = current.toObject();
+          var date;
 
           for (i = 0; i < revisions.length - req.params.back; i += 1) {
 
             patched = jsondiffpatch.unpatch(patched, revisions[i].diff);
+            date = revisions[i].date;
+            date = date.getDate() + "/" + date.getMonth() + "/" + date.getFullYear() + " @ " + date.getHours() + ":" + date.getMinutes();
+
+          }
+          
+          var message = "";
+
+          if (parseInt(req.params.back) !== 0) {
+
+            message += " <a title='go back' href=/revisions/" + req.params.type + "/" + req.params.eid + "/" + (parseInt(req.params.back) - 1) + ">&#10094;</a> ";
+
+          } else {
+
+            message += " ";
 
           }
 
-          iris.modules.frontend.globals.parseTemplateFile([patched.entityType, patched.eid], ["html", patched.entityType, patched.eid], {current:patched}, req.authPass, req).then(function (success) {
+          if (date) {
+
+            message += "Viewing revision from " + date + ".";
+
+          } else {
+
+            message += "Viewing current revision."
+
+          }
+
+          if (req.params.back < revisions.length) {
+
+            message += " <a title='go forward' href=/revisions/" + req.params.type + "/" + req.params.eid + "/" + (parseInt(req.params.back) + 1) + ">&#10095;</a> ";
+
+          } else {
+
+            message += " ";
+
+          }
+
+          iris.message(req.authPass.userid, message, "info");
+
+          iris.modules.frontend.globals.parseTemplateFile([patched.entityType, patched.eid], ["html", patched.entityType, patched.eid], {
+            current: patched
+          }, req.authPass, req).then(function (success) {
+
 
             res.send(success);
 

--- a/modules/extra/revisions/templates/entity_revisions.html
+++ b/modules/extra/revisions/templates/entity_revisions.html
@@ -1,0 +1,11 @@
+<h1>Revisions</h1>
+
+<ul>
+  
+  {{#each revisions}}
+
+    <li><a href="/revisions/{{entityType}}/{{eid}}/{{@index}}">{{this.date}}</a></li> 
+  
+  {{/each}}
+
+</ul>

--- a/modules/extra/revisions/templates/revision_revert.html
+++ b/modules/extra/revisions/templates/revision_revert.html
@@ -1,0 +1,3 @@
+<h1>Revert {{entityType}} to previous version</h1>
+
+[[[form revision_revert,{"entityType":"{{entityType}}", "eid":"{{eid}}", "revision":"{{revision}}"}]]]

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "glob": "^5.0.15",
     "handlebars": "^4.0.4",
     "i18n": "^0.8.1",
+    "jsondiffpatch": "^0.1.43",
     "merge": "^1.2.0",
     "minimatch": "^3.0.0",
     "mkdirp": "^0.5.1",


### PR DESCRIPTION
Introduces an entity revisions module which saves diffs of entity edits.

Past entity revisions can be viewed and reverted to via the administration system

Two improvements to the general entity and entity UI system in the process.
- `hook_entity_update` now contains a context object with the previous state of the entity before the update took place and the new state. Usable by other modules as well.
- `hook_entity_links` is a new hook that adds administrative links for an entity. Eventually these could be edit / delete links etc but for now just the one for revisions has been added. This allows for other modules to easily extend the entity list page.

Further enhancements could include a `state` attribute on an entity that uses the revisions system to enable drafts and other staged content.

[Issue #132]
