### PR TITLE
fix(navigation tags ranking)

### DIFF
--- a/modules/core/forms/forms.js
+++ b/modules/core/forms/forms.js
@@ -318,7 +318,7 @@ iris.modules.forms.registerHook("hook_frontend_embed__form", 0, function (thisHo
     attributes: {
       "src": "/modules/forms/jsonform/lib/jsonform.js"
     },
-    rank: 3
+    rank: 1
   };
 
   variables.tags.headTags["extrafields"] = {
@@ -326,7 +326,7 @@ iris.modules.forms.registerHook("hook_frontend_embed__form", 0, function (thisHo
     attributes: {
       "src": "/modules/forms/extrafields.js"
     },
-    rank: 1
+    rank: 2
   };
 
   variables.tags.headTags["clientforms"] = {

--- a/modules/core/frontend/tags.js
+++ b/modules/core/frontend/tags.js
@@ -25,6 +25,26 @@ iris.modules.frontend.registerHook("hook_frontend_embed__tags", 0, function (thi
 
   }
 
+
+  var tags = [];
+  if(vars.tags[tagName] != undefined){
+
+    Object.keys(vars.tags[tagName]).forEach(function(item, index){
+      tags.push({item: item, rank: vars.tags[tagName][item].rank, data: JSON.stringify(vars.tags[tagName][item])});
+    });
+
+    tags.sort(function(a, b){
+      return  a.rank - b.rank;
+    })
+
+    vars.tags[tagName] = {};
+    tags.forEach(function(item, index){
+      vars.tags[tagName][item.item] = JSON.parse(item.data);
+    });
+
+  };
+
+
   if (vars.tags && vars.tags[tagName]) {
 
     var tagContainer = vars.tags[tagName];


### PR DESCRIPTION
Not sure why the tags are in the structure:

```
tags {
 attr{
     tagName{
      }
  }
}
```

Inside attr I would have it as an array not an object, but that's just a suggestion instead of needing to do a hacky fix for ordering the items.

```
tags {
 attr [
     { tag: tagName, etc}
  ]
}
```

Signed-off-by: Alex Bor alexhbor@gmail.com
