### PR TITLE
Restart hooks with extensible persistence

### DIFF
--- a/boot.js
+++ b/boot.js
@@ -23,19 +23,27 @@ module.exports = function (config) {
 
   // Restart function
 
-  iris.restart = function (userid, where) {
+  iris.restart = function (authPass, data) {
+
+    if (!data) {
+
+      var data = {};
+
+    }
 
     process.nextTick(function () {
 
-      if (userid) {
+      iris.message(authPass.userid, "Server restarted", "success");
 
-        iris.message(userid, "Server restarted", "success");
+      iris.log("info", "Server restarted by " + authPass.userid);
 
-      }
+      iris.invokeHook("hook_restart_send", authPass, null, data).then(function (data) {
+        
+        process.send({
+          restart: data
+        });
 
-      iris.log("info", "Server restarted " + (userid ? " by user " + userid : "") + (where ? " via " + where : ""));
-
-      process.send("restart");
+      })
 
     });
 

--- a/launch_site.js
+++ b/launch_site.js
@@ -16,31 +16,17 @@ var config;
 process.on("message", function (m) {
 
   if (m.launchPath) {
-    
+
     process.chdir(m.launchPath);
 
     var server = require('./boot')(m);
 
   }
 
-  if (m.sessions) {
-
-    Object.keys(m.sessions).forEach(function (user) {
-
-      iris.modules.auth.globals.userList[user] = m.sessions[user];
-
-    });
-
-  }
-
-  if (m.messages) {
-
-    Object.keys(m.messages).forEach(function (user) {
-
-      iris.messageStore[user] = m.messages[user];
-
-    });
-
+  if (m.persist) {
+        
+    iris.invokeHook("hook_restart_receive", "root", m.persist, m.persist);
+    
   }
 
 })

--- a/message.js
+++ b/message.js
@@ -18,22 +18,16 @@ iris.message = function (userid, message, type) {
 
   });
 
-  // Send messages to server for persistence
-
-  process.send({
-    messages: iris.messageStore
-  });
-
 };
 
 iris.readMessages = function (userid) {
-
+  
   var messages = [];
 
   // Return messages and wipe them as being read
 
   if (iris.messageStore[userid]) {
-
+    
     iris.messageStore[userid].forEach(function (message, index) {
 
       messages.push(message);

--- a/modules/core/auth/auth.js
+++ b/modules/core/auth/auth.js
@@ -270,12 +270,15 @@ iris.modules.auth.registerHook("hook_auth_authpass", 0, function (thisHook, data
   // To change the users language, use hook_auth_authpass and then thisHook.authPass.setLocale([language code]);
   if (thisHook.req && thisHook.req.headers && thisHook.req.headers['accept-language']) {
 
-    data.headers = {'accept-language' : thisHook.req.headers['accept-language']};
+    data.headers = {
+      'accept-language': thisHook.req.headers['accept-language']
+    };
 
-  }
-  else {
+  } else {
 
-    data.headers = {'accept-language' : 'en-US,en'};
+    data.headers = {
+      'accept-language': 'en-US,en'
+    };
 
   }
 
@@ -331,8 +334,8 @@ iris.modules.auth.registerHook("hook_auth_maketoken", 0, function (thisHook, dat
       };
 
       iris.modules.auth.globals.userList[data.userid].tokens[authToken] = token;
-      
-      iris.invokeHook("hook_user_login", thisHook.authPass, null, data.userid).then(function(success) {
+
+      iris.invokeHook("hook_user_login", thisHook.authPass, null, data.userid).then(function (success) {
         thisHook.pass(success);
       }, function (fail) {
 
@@ -428,15 +431,15 @@ iris.modules.auth.registerHook("hook_auth_clearauth", 0, function (thisHook, use
 
     if (iris.modules.auth.globals.userList[userid]) {
 
-      iris.invokeHook("hook_user_logout", thisHook.authPass, null, userid).then(function(success){
+      iris.invokeHook("hook_user_logout", thisHook.authPass, null, userid).then(function (success) {
         thisHook.pass(success);
-      }, function(fail) {
+      }, function (fail) {
 
         thisHook.fail(fail);
 
       });
       delete iris.modules.auth.globals.userList[userid];
-       
+
       thisHook.pass(userid);
 
     } else {
@@ -482,7 +485,7 @@ iris.app.post('/auth/deletetoken', function (req, res) {
 });
 
 iris.app.post('/auth/maketoken', function (req, res) {
-  
+
   iris.invokeHook("hook_auth_maketoken", req.authPass, null, {
     userid: req.body.userid
   }).then(function (success) {
@@ -503,13 +506,13 @@ iris.app.get('/auth/checkauth', function (req, res) {
 
 });
 
-Object.observe(iris.modules.auth.globals.userList, function (data) {
+iris.modules.auth.registerHook("hook_restart_send", 0, function (thisHook, data) {
 
-  process.send({
-    sessions: iris.modules.auth.globals.userList
-  });
+  data.sessions = iris.modules.auth.globals.userList;
 
-});
+  thisHook.pass(data);
+
+})
 
 iris.app.post("/logout", function (req, res) {
 

--- a/modules/core/system/system.js
+++ b/modules/core/system/system.js
@@ -21,19 +21,19 @@ iris.modules.system.registerHook("hook_form_render__restart", 0, function (thisH
 
   data.onSubmit = function (errors, values) {
 
-  //  $.post(window.location, values, function (data, err) {
-  ////    window.location.href = window.location.href;
-  //    console.log(values);
-  //    console.log(window.location);
-  //  });
+    //  $.post(window.location, values, function (data, err) {
+    ////    window.location.href = window.location.href;
+    //    console.log(values);
+    //    console.log(window.location);
+    //  });
 
   };
 
   data.form = [
     "*",
     {
-    "type": "help",
-    "helpvalue": "Click below to restart the server."
+      "type": "help",
+      "helpvalue": "Click below to restart the server."
     },
     {
       "type": "submit",
@@ -48,14 +48,48 @@ iris.modules.system.registerHook("hook_form_render__restart", 0, function (thisH
 
 iris.modules.system.registerHook("hook_form_submit__restart", 0, function (thisHook, data) {
 
-  iris.restart(thisHook.authPass.userid, "restart button");
-
-
+  iris.restart(thisHook.authPass, {});
 
   thisHook.pass(data);
 
 });
 
+
+// Send messages to parent process on restart for persistence
+
+iris.modules.system.registerHook("hook_restart_send", 0, function (thisHook, data) {
+
+  data.messages = iris.messageStore;
+
+  thisHook.pass(data);
+
+})
+
+iris.modules.system.registerHook("hook_restart_receive", 0, function (thisHook, data) {
+    
+  if (data.sessions) {
+
+    Object.keys(data.sessions).forEach(function (user) {
+
+      iris.modules.auth.globals.userList[user] = data.sessions[user];
+
+    });
+
+  }
+
+  if (data.messages) {
+
+    Object.keys(data.messages).forEach(function (user) {
+
+      iris.messageStore[user] = data.messages[user];
+
+    });
+
+  }
+  
+  thisHook.pass(data);
+
+})
 
 // Placeholder hook TODO for sending socket message to update log page
 

--- a/modules/core/system/system_modules/modules.js
+++ b/modules/core/system/system_modules/modules.js
@@ -49,83 +49,83 @@ iris.modules.system.registerHook("hook_form_render__modules", 0, function (thisH
   // Search for iris files
 
   var rootParent = iris.rootPath.substring(0, iris.rootPath.length - 7);
-  glob("{" + rootParent + "/**/*.iris.module" +',' + iris.rootPath + "/modules/extra/**/*.iris.module" + "," + iris.sitePath + "/modules/**/*.iris.module" + "}", function (er, files) {
+  glob("{" + rootParent + "/**/*.iris.module" + ',' + iris.rootPath + "/modules/extra/**/*.iris.module" + "," + iris.sitePath + "/modules/**/*.iris.module" + "}", function (er, files) {
 
-      var availableModules = {};
+    var availableModules = {};
 
-      // Loop over all the files and add to the list of available modules
+    // Loop over all the files and add to the list of available modules
 
-      files.forEach(function (file) {
+    files.forEach(function (file) {
 
-        var moduleName = path.basename(file).replace(".iris.module", "");
-        var fileDir = path.dirname(file);
+      var moduleName = path.basename(file).replace(".iris.module", "");
+      var fileDir = path.dirname(file);
 
-        //fileDir = fileDir.replace(iris.rootPath, "") + "/" + moduleName;
+      //fileDir = fileDir.replace(iris.rootPath, "") + "/" + moduleName;
 
-        try {
+      try {
 
-          var file = fs.readFileSync(file, "utf8");
+        var file = fs.readFileSync(file, "utf8");
 
-          file = JSON.parse(file);
+        file = JSON.parse(file);
 
-          file.modueName = moduleName;
-          file.path = fileDir;
+        file.modueName = moduleName;
+        file.path = fileDir;
 
-          availableModules[file.modueName] = file;
+        availableModules[file.modueName] = file;
 
-        } catch (e) {
+      } catch (e) {
 
-          iris.log("error", e);
+        iris.log("error", e);
 
-        }
-
-      });
-
-      // Add enabled modules to form
-
-      data.form = [];
-
-      Object.keys(availableModules).forEach(function (moduleName) {
-
-        var currentModule = availableModules[moduleName];
-
-        data.schema[moduleName] = {
-          "type": "object",
-          "properties": {
-            "enabled": {
-              "type": "boolean",
-              "title": currentModule.name + (currentModule.dependencies ? " - requires " + Object.keys(currentModule.dependencies).join(",") : ""),
-              "description": (currentModule.description ? currentModule.description : ""),
-              "default": iris.modules[moduleName] ? true : false
-            },
-            "weight": {
-              "type": "hidden",
-              "default": currentModule.weight
-            },
-            "dependencies": {
-              "type": "hidden",
-              "default": (currentModule.dependencies ? Object.keys(currentModule.dependencies).join(",") : null)
-            }
-          }
-        };
-
-        data.form.push({
-          "key": moduleName,
-          "inlinetitle": thisHook.authPass.t("Enable the <b>{{name}}</b> module", {
-            name: currentModule.name
-          })
-        })
-
-      });
-
-      data.form.push({
-        type: "submit",
-        title: "submit"
-      });
-
-      thisHook.pass(data);
+      }
 
     });
+
+    // Add enabled modules to form
+
+    data.form = [];
+
+    Object.keys(availableModules).forEach(function (moduleName) {
+
+      var currentModule = availableModules[moduleName];
+
+      data.schema[moduleName] = {
+        "type": "object",
+        "properties": {
+          "enabled": {
+            "type": "boolean",
+            "title": currentModule.name + (currentModule.dependencies ? " - requires " + Object.keys(currentModule.dependencies).join(",") : ""),
+            "description": (currentModule.description ? currentModule.description : ""),
+            "default": iris.modules[moduleName] ? true : false
+          },
+          "weight": {
+            "type": "hidden",
+            "default": currentModule.weight
+          },
+          "dependencies": {
+            "type": "hidden",
+            "default": (currentModule.dependencies ? Object.keys(currentModule.dependencies).join(",") : null)
+          }
+        }
+      };
+
+      data.form.push({
+        "key": moduleName,
+        "inlinetitle": thisHook.authPass.t("Enable the <b>{{name}}</b> module", {
+          name: currentModule.name
+        })
+      })
+
+    });
+
+    data.form.push({
+      type: "submit",
+      title: "submit"
+    });
+
+    thisHook.pass(data);
+
+  });
 
 });
 
@@ -239,6 +239,9 @@ iris.modules.system.registerHook("hook_form_submit__modules", 0, function (thisH
 
   }
 
-  iris.restart(thisHook.authPass.userid, "modules page");
+  iris.restart(thisHook.authPass, {
+    enabledModules: enabledList,
+    disabledModules: disabledList
+  });
 
 });

--- a/modules/core/system/system_modules/themes.js
+++ b/modules/core/system/system_modules/themes.js
@@ -113,7 +113,7 @@ iris.modules.system.registerHook("hook_form_submit__themes", 0, function (thisHo
 
   fs.writeFileSync(iris.configPath + "/system/active_theme.json", JSON.stringify(output));
 
-  iris.restart(thisHook.authPass.userid, "themes page");
+  iris.restart(thisHook.authPass, {});
 
   thisHook.pass(data);
 

--- a/modules/core/user/user.js
+++ b/modules/core/user/user.js
@@ -621,7 +621,7 @@ iris.modules.user.registerHook("hook_form_submit__set_first_user", 0, function (
             if (enabled) {
               console.log('restarting');
               iris.message(uid, ap.t("Don't worry, that short glitch was the server restarting to install the Standard profile."), "info");
-              iris.restart(uid, ap.t("UI modules enabled."));
+              iris.restart(thisHook.authPass, {});
             }
           });
         });


### PR DESCRIPTION
Added `hook_restart_send` and `hook_restart_receive` (each get a data object that
can be added to).

`iris.restart` has changed to take the an `authPass` (was a user id previously) and an optional object
(previously a message containing where the restart happened) whose contents are merged with the persistent data when restarting (an example of modules enabled and modules disabled is already coded into the module administration form)

This fixes dependence on the deprecated `Object.observe` and also makes room for things like: https://github.com/CityWebConsultants/Iris/issues/206 and form key persistence over restarts.
