### PR TITLE
Entity reference field improvements

### DIFF
--- a/modules/extra/entityReference/entityReference.iris.field
+++ b/modules/extra/entityReference/entityReference.iris.field
@@ -1,4 +1,7 @@
 {
   "name": "Entity Reference",
-  "type": "String"
+  "type": {
+    "eid": "String",
+    "entityType": "String"
+  }
 }

--- a/modules/extra/entityUI/entityUI.js
+++ b/modules/extra/entityUI/entityUI.js
@@ -774,7 +774,7 @@ iris.modules.entityUI.registerHook("hook_form_submit__entity", 0, function (this
         iris.invokeHook("hook_entity_field_fieldTypeType_save__" + fieldTypeType, thisHook.authPass, {
           value: newValue,
           field: field
-        }, value).then(function (finalValue) {
+        }, newValue).then(function (finalValue) {
 
           callback(finalValue);
 


### PR DESCRIPTION
Plus bugfix on entity edit where field save overrides were skipped.

Entity reference fields are now stored as `{"entityType":"type", "eid":"eid"}` so they can be used in a template (for example in entity fetch embeds).
