### PR TITLE
Reduce scope of menu module's getBaseLinks function

### DIFF
--- a/modules/core/menu/menu.js
+++ b/modules/core/menu/menu.js
@@ -210,7 +210,7 @@ iris.modules.menu.globals.getBaseLinks = function (baseurl) {
 
         menu.forEach(function (menuLink) {
 
-          if (menuLink.parent && menuLink.parent.indexOf(basePath) !== -1) {
+          if (menuLink.parent && menuLink.parent === basePath) {
 
             links.push({
               path: routePath,


### PR DESCRIPTION
getBaseLinks() helper was fetching a flat list of all sub links of sub links as well. Could eventually be modified to fetch the whole tree in an ordered list but as menus are being looked into separately this is a quick fix for some broken landing pages.
