### PR TITLE
Updating jshint and removing jasmine tests

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,8 +1,12 @@
 {
   "undef": true,
   "unused": false,
-  "predef": ["iris","mongoose","Promise", "CKEDITOR", "JSONForm", "ckeditor"],
+  "predef": ["iris","mongoose","Promise", "CKEDITOR", "JSONForm", "ckeditor", "jQuery", "$", "e"],
   "node" : true,
   "browser": true,
-  "sub" : true
+  "sub" : true,
+  "loopfunc": true,
+  "maxdepth": 4,
+  "maxerr": 2000
 }
+

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -2,30 +2,18 @@ module.exports = function (grunt) {
     'use strict';
 
     grunt.initConfig({
-        jasmine_node: {
-            api_entity_actions: {
-                options: {
-                    coverage: {},
-                    forceExit: false,
-                    match: '.',
-                    matchAll: false,
-                    specFolders: ['iris_core/test'],
-                    extensions: 'js',
-                    specNameMatcher: 'spec',
-                    captureExceptions: true,
-                    junitreport: {
-                        report: true,
-                        savePath: './build/reports/jasmine/',
-                        useDotNotation: true,
-                        consolidate: true
-                    }
-                },
-                src: ['**/*.js']
-            }
+        jshint: {
+            options: {
+                jshintrc: true,
+                // Squash warning on dot-notation.
+                "-W069": true,
+            },
+            // Include core and exclude libraries and dependencies.
+            all: ['*.js', 'modules/core/**/*.js', 'modules/extra/**/*.js', '!modules/core/**/deps/*', '!*min.js']
         }
     });
 
-    grunt.loadNpmTasks('grunt-jasmine-node-coverage');
+    grunt.loadNpmTasks('grunt-contrib-jshint');
+    grunt.registerTask('default', ['jshint']);
 
-    grunt.registerTask('default', 'jasmine_node');
 };

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   "devDependencies": {
     "frisby": "^0.8.5",
     "grunt": "^0.4.5",
+    "grunt-contrib-jshint": "^1.0.0",
     "grunt-jasmine-node-coverage": "^0.4.1",
     "jasmine-node": "^1.14.5",
     "jshint": "^2.9.1"


### PR DESCRIPTION
Removed jasmine tests
Amending JSHint settings

Already setup on my local so not sure if these are all the steps...

In irisjs root:

`npm install --only=dev`
`npm install -g grunt-cli`
`grunt jshint`
