### PR TITLE
Remove Windows-breaking example.js and add install CLI

### DIFF
--- a/iriscli.js
+++ b/iriscli.js
@@ -1,0 +1,142 @@
+#! /usr/bin/env node
+
+var cli = {};
+var prompt = require("prompt");
+var fs = require("fs");
+var toSource = require("tosource");
+prompt.colors = false;
+
+cli.install = function (configSavePath) {
+
+  prompt.start();
+
+  var schema = {
+    properties: {
+      sitePath: {
+        description: "Enter the path you wish to save your path config",
+        default: "/mysite",
+      },
+      port: {
+        type: "integer",
+        default: "4000",
+        description: "which port do you wish to run the iris server on?"
+      },
+      https: {
+        description: "Do you wish to use HTTPS? (true/false)",
+        required: true,
+        type: "boolean",
+        default: false
+      },
+      db_server: {
+        "description": "Where is the MongoDB database running?",
+        "default": "localhost"
+      },
+      db_port: {
+        "description": "Which port is the database running on? Enter 0 to skip.",
+        "default": 27017
+      },
+      db_name: {
+        "description": "what do you want the database name to be? Enter 0 to skip.",
+        "default": "iris"
+      },
+      "max_file_size": {
+        "description": "max file size",
+        "type": "integer",
+        "default": 10
+      }
+    }
+  };
+
+  prompt.get(schema, function (err, result) {
+    if (err) {
+      console.error(err);
+      process.exit();
+    }
+
+    if (parseInt(result.db_port) === 0) {
+
+      delete result.db_port;
+
+    }
+
+    if (parseInt(result.db_name) === 0) {
+
+      delete result.db_name;
+
+    }
+
+    var installIris = {
+      properties: {
+        install: {
+          description: "Install iris packages?",
+          type: "boolean",
+          default: true
+        }
+      }
+    };
+
+    prompt.get(installIris, function (err, install) {
+
+      var saveLaunchFile = function () {
+
+        var launchFile = configSavePath[0] || "iris";
+
+        var file = `require("irisjs")(${toSource(result)});`
+
+        fs.writeFileSync(launchFile + ".js", file);
+
+        console.log("Run 'node " + launchFile + "' to launch");
+
+      }
+
+      if (install.install) {
+
+        console.log("installing Iris");
+
+        var exec = require('child_process').exec,
+          child;
+
+        child = exec('npm install irisjs',
+          function (error, stdout, stderr) {
+            console.log('stdout: ' + stdout);
+            console.log('stderr: ' + stderr);
+            if (error !== null) {
+              console.log('exec error: ' + error);
+            }
+          });
+
+        child.on("close", function () {
+
+          saveLaunchFile();
+
+        })
+
+      } else {
+
+        saveLaunchFile();
+
+      }
+
+    })
+
+  });
+
+}
+
+// Run script 
+
+var userArgs = process.argv.slice(2);
+
+try {
+
+  var first = userArgs[0];
+
+  var rest = userArgs.slice(1);
+
+  cli[first](rest);
+
+} catch (e) {
+
+  console.error(e);
+
+}

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "nodemailer": "^1.11.0",
     "path-to-regexp": "^1.2.1",
     "prettydiff": "^1.16.6",
+    "prompt": "^1.0.0",
     "sanitize-html": "^1.10.0",
     "socket.io": "^1.2.1",
     "tosource": "^1.0.0"
@@ -44,7 +45,9 @@
     "jshint": "^2.9.1"
   },
   "scripts": {
-    "test": "grunt default",
-    "postinstall": "cp example.js ../../example.js"
+    "test": "grunt default"
+  },
+  "bin": {
+    "irisjs": "iriscli.js"
   }
 }


### PR DESCRIPTION
`npm install -g irisjs` will now add `irisjs` to the command line path.

Currently this serves only one use `irisjs install sitename` which steps through a list of config questions, installs irisjs locally and creates a launch file with the settings the user put in.

There is room to add other command line options in the future. Particularly through the use of sockets to access an iris installation while it's running and enable modules, debug etc.

Requires an npm install for the `prompt` library that makes asking questions on the command line easier with defaults and such.

To test this pull request locally: pull it in, navigate to its directory and run `npm link`. That will do the same as `npm install -g`
