### PR TITLE
Fix bug with date fields

### DIFF
--- a/modules/core/system/system_modules/fields.js
+++ b/modules/core/system/system_modules/fields.js
@@ -170,6 +170,12 @@ var dateToForm = function (value) {
     return s;
   };
 
+  if (typeof value == 'string') {
+
+    value = new Date(value);
+
+  }
+
   if (value) {
 
     var year = value.getFullYear();


### PR DESCRIPTION
The date was coming through as a string which caused errors. This simply makes a date string into a date object
