### PR TITLE
Function to run when all forms on the page have rendered

### DIFF
--- a/modules/core/forms/static/clientforms.js
+++ b/modules/core/forms/static/clientforms.js
@@ -45,7 +45,7 @@ $(window).load( function () {
     }
     iris.forms.renderForm(form);
 
-    if(index == totalForms - 1){
+    if(index == totalForms - 1 && typeof window.formComplete_all == "function"){
        formComplete_all();
     }
 

--- a/modules/core/forms/static/clientforms.js
+++ b/modules/core/forms/static/clientforms.js
@@ -37,12 +37,18 @@ $(window).load( function () {
     iris.forms.cache.push(formId);
   };
 
-  Object.keys(iris.forms).forEach(function (form) {
+  var totalForms = Object.keys(iris.forms).length;
+  Object.keys(iris.forms).forEach(function (form, index) {
 
     if (iris.forms[form].form && typeof iris.forms[form].form.onSubmit != 'function') {
       iris.forms[form].form.onSubmit = iris.forms.onSubmit;
     }
     iris.forms.renderForm(form);
+
+    if(index == totalForms - 1){
+       formComplete_all();
+    }
+
   });
 
   // Fire event after all forms have loaded.


### PR DESCRIPTION
Similar to after a single form, a function can be run once all forms have been rendered.

Function name is `formComplete_all`

Signed-off-by: Alex Bor alexhbor@gmail.com
