### PR TITLE
Escape double quotes in liveload template attribute

### DIFF
--- a/modules/core/entity/static/templates.js
+++ b/modules/core/entity/static/templates.js
@@ -535,8 +535,10 @@ iris.liveLoadUpdate = function () {
   for (i = 0; i < liveLoaders.length; i += 1) {
 
     var parent = liveLoaders[i];
+    
+    var templateCode = parent.querySelector(".iris-live-load-source").getAttribute("data-iris-live-load-template").split("&#34;").join('"');
 
-    var template = Handlebars.compile(parent.querySelector(".iris-live-load-source").getAttribute("data-iris-live-load-template"));
+    var template = Handlebars.compile(templateCode);
     var child = parent.querySelector(".iris-live-load-output");
 
     child.innerHTML = template(entityContainers);

--- a/modules/core/frontend/handlebars_helpers.js
+++ b/modules/core/frontend/handlebars_helpers.js
@@ -121,7 +121,7 @@ iris.modules.frontend.registerHook("hook_frontend_handlebars_extend", 0, functio
 
       var output = "<div class='iris-live-load'>";
       output += "{{{{iris_handlebars_ignore}}}}";
-      output += '<div class="iris-live-load-source" data-iris-live-load-template="' + options.fn().trim().replace(/(\r\n|\n|\r)/gm, "") + '">';
+      output += '<div class="iris-live-load-source" data-iris-live-load-template="' + options.fn().trim().replace(/(\r\n|\n|\r)/gm, "").split("\"").join("&#34;") + '">';
       output += "</div>";
       output += "{{{{/iris_handlebars_ignore}}}}";
       output += "\n";


### PR DESCRIPTION
The entity liveload template script wasn't escaping double quotes so if it contained HTML the browser went funny. This quick and simple fix encodes and decodes them to/from HTML entities.
