### PR TITLE
Check if error has an error stack to prevent crash on some error logs

### DIFF
--- a/boot.js
+++ b/boot.js
@@ -443,7 +443,15 @@ module.exports = function (config) {
 
     if (err) {
 
-      iris.log("error", "Error on line " + err.stack[0].getLineNumber() + " of " + err.stack[0].getFileName() + " " + err.message);
+      if (err.stack && err.stack[0]) {
+
+        iris.log("error", "Error on line " + err.stack[0].getLineNumber() + " of " + err.stack[0].getFileName() + " " + err.message);
+
+      } else {
+        
+        iris.log("error", err);
+        
+      }
 
       iris.invokeHook("hook_display_error_page", req.authPass, {
         error: 500,


### PR DESCRIPTION
If a caught error didn't have a stack it was crashing the system because `err.stack[0].getLineNumber()` didn't exist. Wrapped it a condition block.
