### PR TITLE
Response intercept hook

### DIFF
--- a/server.js
+++ b/server.js
@@ -92,11 +92,16 @@ iris.app.use(function (req, res, next) {
 
 });
 
-// Allow responses to be intercepted
+/**
+ * @member hook_response_intercept
+ * Response intercept hook
+ *
+ * Allow responses to be intercepted before being sent to the client
+ */
 
 iris.app.use(function (req, res, next) {
 
-  newSend = res.send;
+  var newSend = res.send;
 
   res.send = function (body) {
 
@@ -130,11 +135,25 @@ iris.app.use(function (req, res, next) {
 
         }
 
-
       }, function (fail) {
 
         iris.log("error", fail);
-        res.status(500).send("Error");
+        
+        iris.invokeHook("hook_display_error_page", req.authPass, {
+          error: 500,
+          req: req,
+          res: res
+        }).then(function (success) {
+
+          res.status(500);
+          newSend.call(that, success);
+
+        }, function (fail) {
+
+           res.status(500);
+          newSend.call(that, "Something went wrong");
+
+        });
 
       })
 


### PR DESCRIPTION
Allow responses from the server to be intercepted and overwritten/altered before they are sent back to the client. Was built for use in no clientside JavaScript forms pull request but has many wider uses. Could possibly even be used to replace the headertags system.

~~Going to tidy up a few things here and add comments but putting it up to show it's been worked on.~~
