### PR TITLE
Don't overwrite entity context if already set

### DIFF
--- a/modules/core/frontend/frontend.js
+++ b/modules/core/frontend/frontend.js
@@ -96,7 +96,11 @@ iris.modules.frontend.globals.getTemplate = function (entity, authPass, optional
 
     // Check if the current person can access the entity itself
 
-    var context = {};
+    if (!context) {
+
+      var context = {};
+
+    }
 
     context.tags = {
       headTags: {},


### PR DESCRIPTION
This part of frontend.js should probably be tidied up but this is a quick fix to an overwriting bug.
