### PR TITLE
Various email system bug fixes

### DIFF
--- a/modules/core/email/email.js
+++ b/modules/core/email/email.js
@@ -1,5 +1,5 @@
 var nodemailer = require('nodemailer');
-iris.registerModule("email",__dirname);
+iris.registerModule("email", __dirname);
 
 /**
  * Define callback routes.
@@ -26,7 +26,7 @@ iris.route.get('/admin/config/mail-settings', routes.mail, function (req, res) {
 
 
   iris.modules.frontend.globals.parseTemplateFile(["mail-settings"], ['admin_wrapper'], {
-    title : "Administer mail system"
+    title: "Administer mail system"
   }, req.authPass, req).then(function (success) {
 
     res.send(success)
@@ -41,14 +41,17 @@ iris.route.get('/admin/config/mail-settings', routes.mail, function (req, res) {
 
 });
 
-  /**
-   * Implements iris.modules.triggers.globals.registerAction().
-   *
-   * Registers an action that can be triggered by the system or directly. It describes
-   * the form fields that are used in the execution of the action.
-   *
-   */
-  if(iris.modules.triggers) {
+/**
+ * Implements iris.modules.triggers.globals.registerAction().
+ *
+ * Registers an action that can be triggered by the system or directly. It describes
+ * the form fields that are used in the execution of the action.
+ *
+ */
+
+process.on("dbReady", function () {
+
+  if (iris.modules.triggers) {
     iris.modules.triggers.globals.registerAction("email", {
       "subject": {
         "type": "text",
@@ -67,170 +70,187 @@ iris.route.get('/admin/config/mail-settings', routes.mail, function (req, res) {
         "title": "Sender address",
         "required": true,
       },
-      message: {
+      body: {
         "type": "textarea",
         "title": "Message"
       }
     });
   }
 
-  /**
-   * Implements hook_triggers_[action_name].
-   *
-   * Hook that gets fired when the email action is triggered.
-   */
+})
+
+/**
+ * Implements hook_triggers_[action_name].
+ *
+ * Hook that gets fired when the email action is triggered.
+ */
 iris.modules.email.registerHook("hook_triggers_email", 0, function (thisHook, data) {
 
-    iris.modules.email.globals.sendEmail(thisHook.context);
-    thisHook.pass(data);
+  iris.modules.email.globals.sendEmail(thisHook.context.params, thisHook.authPass);
+  thisHook.pass(data);
 
 });
 
-  /**
-   * Implements hook_form_render__[form_name].
-   *
-   * This form gets a list of mailSystem handlers from modules implementing hook_registerMailSystem.
-   */
+/**
+ * Implements hook_form_render__[form_name].
+ *
+ * This form gets a list of mailSystem handlers from modules implementing hook_registerMailSystem.
+ */
 
 iris.modules.email.registerHook("hook_form_render__mailSettings", 0, function (thisHook, data) {
-    
-    var defaultSettings = {"mailSystem" : {}};
-    iris.invokeHook("hook_registerMailSystem", thisHook.authPass, {}, defaultSettings).then(function(success){
 
-        data.schema.mailSystem = {
-            "type": "string",
-            "title": thisHook.authPass.t("Choose mail system"),
-            "enum": Object.keys(success.mailSystem)
-        };
-        
-        data.form = [
-        {
-            "key": "mailSystem",
-            "type": "select",
-            "titleMap": success.mailSystem
+  var defaultSettings = {
+    "mailSystem": {}
+  };
+  iris.invokeHook("hook_registerMailSystem", thisHook.authPass, {}, defaultSettings).then(function (success) {
+
+    data.schema.mailSystem = {
+      "type": "string",
+      "title": thisHook.authPass.t("Choose mail system"),
+      "enum": Object.keys(success.mailSystem)
+    };
+
+    data.form = [
+      {
+        "key": "mailSystem",
+        "type": "select",
+        "titleMap": success.mailSystem
         },
-        {
-          "type": "submit",
-          "title": thisHook.authPass.t("Submit")
+      {
+        "type": "submit",
+        "title": thisHook.authPass.t("Submit")
         }];
-    
 
-        thisHook.pass(data);
 
-    }, function(fail){
+    thisHook.pass(data);
 
-        iris.log("error", fail);
-        thisHook.fail(data);
+  }, function (fail) {
 
-    });
-    
+    iris.log("error", fail);
+    thisHook.fail(data);
+
+  });
+
 });
 
-  /**
-   * Implements hook_form_submit__[form_name].
-   *
-   * Saves the chosen mailSystem.
-   *
-   */
+/**
+ * Implements hook_form_submit__[form_name].
+ *
+ * Saves the chosen mailSystem.
+ *
+ */
 iris.modules.email.registerHook("hook_form_submit__mailSettings", 0, function (thisHook, data) {
-    
-    iris.saveConfig(thisHook.context.params, 'email', 'mail_system');
-    
-    iris.message(thisHook.authPass.userid, "Settings saved", "info");
-    thisHook.pass(function (res) {
-        res.send("/admin/config/mail-settings");
 
-    });
+  iris.saveConfig(thisHook.context.params, 'email', 'mail_system');
 
-});
+  iris.message(thisHook.authPass.userid, "Settings saved", "info");
+  thisHook.pass(function (res) {
+    res.send("/admin/config/mail-settings");
 
- /**
-   * Implements hook_registerMailSystem.
-   *
-   * Provides the 'Simple mail' option which will attempt to send emails directly from 
-   * your system with no options.
-   *
-   */
-iris.modules.email.registerHook("hook_registerMailSystem", 0, function(thisHook, data){
-
-    data.mailSystem["email"] = "Simple mail";
-    thisHook.pass(data);
+  });
 
 });
 
- /**
-   * Implements hook_sendMail.
-   *
-   * The sendMail hook is run everytime an email is triggered. This hook implements the
-   * 'Simple mail' mailSystem and sends emails directly from the system.
-   *
-   */
-iris.modules.email.registerHook("hook_sendMail", 0, function(thisHook, data){
+/**
+ * Implements hook_registerMailSystem.
+ *
+ * Provides the 'Simple mail' option which will attempt to send emails directly from 
+ * your system with no options.
+ *
+ */
+iris.modules.email.registerHook("hook_registerMailSystem", 0, function (thisHook, data) {
 
-    thisHook.context.sendMail({
-        from: data.from,
-        to: data.to,
-        subject: data.subject,
-        html: data.body
-    }, function (err, response) {
-        data.log = (err || response);
-    });
-    
-    thisHook.pass(data);
+  data.mailSystem["email"] = "Simple mail";
+  thisHook.pass(data);
 
 });
 
- /**
-   * Implements iris.modules.[module_name].globals.mailTransporter()
-   *
-   * Transporters are required for send emails via nodemailer. 
-   *
-   */
-iris.modules.email.globals.mailTransporter = function() {
-    
-    return nodemailer.createTransport();
-    
+/**
+ * Implements hook_sendMail.
+ *
+ * The sendMail hook is run everytime an email is triggered. This hook implements the
+ * 'Simple mail' mailSystem and sends emails directly from the system.
+ *
+ */
+iris.modules.email.registerHook("hook_sendMail", 0, function (thisHook, data) {
+
+  thisHook.context.sendMail({
+    from: data.from,
+    to: data.to,
+    subject: data.subject,
+    html: data.body
+  }, function (err, response) {
+
+    data.log = (err || response);
+
+    if (err) {
+      
+      thisHook.fail(err);
+
+    } else {
+
+      thisHook.pass(data);
+
+    }
+
+  });
+
+
+});
+
+/**
+ * Implements iris.modules.[module_name].globals.mailTransporter()
+ *
+ * Transporters are required for send emails via nodemailer. 
+ *
+ */
+iris.modules.email.globals.mailTransporter = function () {
+
+  return nodemailer.createTransport();
+
 }
 
 
- /**
-   * Function to send emails from Iris. This function can be called directly or triggered
-   * by system actions.
-   *
-   * @param {object} args - An object of the basic required email fields such as 'to', 
-   * 'from', 'subject', 'text'.
-   * @param {object} authPass - The current authPass object.
-   *
-   */
-iris.modules.email.globals.sendEmail = function(args, authPass) {
-    
-    iris.readConfig('email', 'mail_system').then(function (config) {
+/**
+ * Function to send emails from Iris. This function can be called directly or triggered
+ * by system actions.
+ *
+ * @param {object} args - An object of the basic required email fields such as 'to', 
+ * 'from', 'subject', 'text'.
+ * @param {object} authPass - The current authPass object.
+ *
+ */
+iris.modules.email.globals.sendEmail = function (args, authPass) {
 
-        if (typeof config.mailSystem == 'undefined') {
-            config.mailSystem = 'email';
-        }
-        // Get selected mail system
-        var transporter = iris.modules[config.mailSystem].globals.mailTransporter();
-    
-        iris.invokeHook("hook_sendMail", authPass, transporter, args).then(function(success){
-            iris.log('notice', 'Email sent to: ', success.to);
-            iris.message(authPass.userid, authPass.t("Email sent"), "info");
-        }
-        , function(fail){
+  iris.readConfig('email', 'mail_system').then(function (config) {
 
-            iris.log("error", fail);
+    if (typeof config.mailSystem == 'undefined') {
+      config.mailSystem = 'email';
+    }
+    // Get selected mail system
+    var transporter = iris.modules[config.mailSystem].globals.mailTransporter();
 
-        });
+    iris.invokeHook("hook_sendMail", authPass, transporter, args).then(function (success) {
 
-
+      iris.log('info', 'Email sent to: ' + success.to);
+      iris.message(authPass.userid, authPass.t("Email sent"), "info");
     }, function (fail) {
-
-      // Add default if it doesn't exist.
-      iris.saveConfig({email: 'Simple mail'}, 'email', 'mail_system');
-      iris.modules.email.globals.sendEmail(args, authPass);
-
-      iris.log("error", fail);
+      
+      iris.log("error", JSON.stringify(fail));
 
     });
-    
+
+
+  }, function (fail) {
+
+    // Add default if it doesn't exist.
+    iris.saveConfig({
+      email: 'Simple mail'
+    }, 'email', 'mail_system');
+    iris.modules.email.globals.sendEmail(args, authPass);
+
+    iris.log("error", fail);
+
+  });
+
 }

--- a/modules/core/user/user.js
+++ b/modules/core/user/user.js
@@ -168,8 +168,8 @@ iris.route.get("/user/reset/*", routes.reset, function (req, res) {
   if (params[3]) {
     action = params[3];
   }
-
-  iris.invokeHook("hook_entity_fetch", req.authPass, null, {
+  
+  iris.invokeHook("hook_entity_fetch", "root", null, {
     "entities": ["user"],
     "queries": [{
       "field": "eid",
@@ -403,8 +403,8 @@ iris.modules.user.registerHook("hook_form_render__passwordReset", 0, function (t
  * Submit handler for passwordReset.
  */
 iris.modules.user.registerHook("hook_form_validate__passwordReset", 0, function (thisHook, data) {
-
-  iris.invokeHook("hook_entity_fetch", thisHook.authPass, null, {
+    
+  iris.invokeHook("hook_entity_fetch", "root", null, {
     "entities": ["user"],
     "queries": [{
       "field": "username",
@@ -412,7 +412,7 @@ iris.modules.user.registerHook("hook_form_validate__passwordReset", 0, function 
       "value": thisHook.context.params.username
       }]
   }).then(function (entities) {
-
+    
     if (entities) {
 
       var doc = entities[0];
@@ -435,7 +435,7 @@ iris.modules.user.registerHook("hook_form_validate__passwordReset", 0, function 
  */
 iris.modules.user.registerHook("hook_form_submit__passwordReset", 0, function (thisHook, data) {
 
-  iris.invokeHook("hook_entity_fetch", thisHook.authPass, null, {
+  iris.invokeHook("hook_entity_fetch", "root", null, {
     "entities": ["user"],
     "queries": [{
       "field": "username",
@@ -463,13 +463,26 @@ iris.modules.user.registerHook("hook_form_submit__passwordReset", 0, function (t
       "name": doc.username,
       "sitename": thisHook.req.headers.host
     }, thisHook.req.authPass, thisHook.req).then(function (body) {
+      
+      var email;
+      
+      if(!iris.config.siteEmail){
+        
+        email = "irisjs@irisjs.org"
+        
+      } else {
+        
+        email = iris.config.siteEmail
+        
+      }
 
       var args = {
-        from: 'adam@therabbitden.com',
+        from: email,
         to: thisHook.context.params.username,
         subject: 'Password reset',
         body: body
       };
+            
       iris.modules.email.globals.sendEmail(args, thisHook.authPass);
 
       thisHook.pass(data);


### PR DESCRIPTION
- User password reset entity fetch called as root as current anonymous user may not have permission to view user accounts.
- Email trigger was not set up as triggers module was not loaded by the time the email module was. Fixed by wrapping in a `dbReady` event.
- Trigger was sending through incorrect parameters
- Email from address was hardcoded to `adam@therabbitden.com` . Changed to allow for a sendEmail variable in config. If not set, sets to `irisjs@irisjs.org` as a slightly better default. [fixes #277]
- Log email errors better. Even failed sends were being marked as sent. JSON stringifying whatever the email server sends back and logging on error via iris.log
