### PR TITLE
Config diff system improvements

### DIFF
--- a/modules/extra/configUI/templates/admin_config_diff.html
+++ b/modules/extra/configUI/templates/admin_config_diff.html
@@ -1,0 +1,41 @@
+<script type="text/javascript" src="/jsondiffpatch/public/build/jsondiffpatch.min.js"></script>
+<script type="text/javascript" src="/jsondiffpatch/public/build/jsondiffpatch-formatters.min.js"></script>
+<link rel="stylesheet" href="/jsondiffpatch/public/formatters-styles/html.css" type="text/css" />
+<link rel="stylesheet" href="/jsondiffpatch/public/formatters-styles/annotated.css" type="text/css" />
+
+<div style="display:none" id="current">{{current}}</div>
+<div style="display:none" id="staging">{{staging}}</div>
+
+<h2>{{file}}</h2>
+
+<div id="diff"></div>
+
+<script>
+
+  var current = document.getElementById("current").innerHTML;
+  var staging = document.getElementById("staging").innerHTML;
+  
+  try {
+    
+  current = JSON.parse(current);
+    
+  } catch(e){
+    
+    
+  }
+  
+  try {
+    
+  staging = JSON.parse(staging);
+    
+  } catch(e){
+    
+    
+  }
+  
+  
+  var diff = jsondiffpatch.diff(staging,current);
+
+  document.getElementById("diff").innerHTML = jsondiffpatch.formatters.html.format(diff);
+
+</script>

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "handlebars": "^4.0.4",
     "i18n": "^0.8.1",
     "jsdom": "^9.3.0",
+    "jsondiffpatch": "^0.1.43",
     "merge": "^1.2.0",
     "minimatch": "^3.0.0",
     "mkdirp": "^0.5.1",
@@ -26,7 +27,6 @@
     "nedb": "^1.8.0",
     "nodemailer": "^1.11.0",
     "path-to-regexp": "^1.2.1",
-    "prettydiff": "^1.16.6",
     "sanitize-html": "^1.10.0",
     "socket.io": "^1.2.1",
     "tosource": "^1.0.0"


### PR DESCRIPTION
- Replace huge [prettyDiff](https://www.npmjs.com/package/pretty-diff) library with better, smaller [jsondiffpatch](https://www.npmjs.com/package/jsondiffpatch) library.
- Cut out duplicates in diff reporting
- Fix excess, unused "diff" menu item

Requires `npm install` for `jsondiffpatch`. `prettydiff` will be removed on fresh Iris install.

Fixes #216
