### PR TITLE
Allow JSONForm field schema to directly write to field render settings

### DIFF
--- a/modules/core/forms/static/clientforms.js
+++ b/modules/core/forms/static/clientforms.js
@@ -4,6 +4,43 @@ $(window).load(function () {
   iris.forms.cache = [];
   var $form;
 
+  // Allow JSONForm field schema object to set form render object settings directly
+
+  Object.keys(JSONForm.elementTypes).forEach(function (type) {
+
+    var elementType = JSONForm.elementTypes[type];
+
+    if (!elementType.onBeforeRender) {
+
+      elementType.onBeforeRender = function () {
+
+
+      };
+
+    }
+
+    var old = elementType.onBeforeRender;
+    elementType.onBeforeRender = function () {
+
+      if (arguments[1].schemaElement && arguments[1].schemaElement.renderSettings) {
+
+
+        if (!arguments[1].formElement) {
+
+          arguments[1].formElement = {};
+
+        }
+
+        Object.assign(arguments[1].formElement, arguments[1].schemaElement.renderSettings);
+        Object.assign(arguments[1], arguments[1].schemaElement.renderSettings);
+
+      }
+
+      old.apply(this, arguments);
+    };
+
+  })
+
   // Remove static forms.
   $("[data-static-form]").remove();
 
@@ -48,8 +85,8 @@ $(window).load(function () {
     }
     iris.forms.renderForm(form);
 
-    if(index == totalForms - 1 && typeof window.formComplete_all == "function"){
-       formComplete_all();
+    if (index == totalForms - 1 && typeof window.formComplete_all == "function") {
+      formComplete_all();
     }
 
   });


### PR DESCRIPTION
Controversial but it's such an annoying part of JSONForm I got tired of hacking around it and put this in. The old way still works so the JSONForm docs still apply, but I've added a new setting to a JSONForm field schema called `renderSettings`. Anything passed in to that gets merged with the form object when the form is rendered (even if one hasn't been defined).

This means you can define all the JSONForm stuff you need directly, classes etc, in the same object if you want.

Is finally allowing us to get rid of the schema vs display seperation a bad idea? I understand why JSONForm tries it, it just isn't managable on complex dynamic form fields. As we've found time and time again.
