### PR TITLE
Allow hook_entity_fetch to use context object for persistent query object

### DIFF
--- a/modules/core/entity/entity_fetch.js
+++ b/modules/core/entity/entity_fetch.js
@@ -16,6 +16,12 @@
  */
 iris.modules.entity.registerHook("hook_entity_fetch", 0, function (thisHook, fetchRequest) {
 
+  if (thisHook.context) {
+
+    fetchRequest = thisHook.context;
+
+  }
+  
   var entityTypes = [];
 
   // Populate list of targetted DB entities

--- a/modules/core/entity/entity_views.js
+++ b/modules/core/entity/entity_views.js
@@ -11,7 +11,7 @@ var fs = require("fs");
 
 iris.modules.entity.registerHook("hook_frontend_embed__entity", 0, function (thisHook, data) {
 
-  iris.invokeHook("hook_entity_fetch", thisHook.authPass, thisHook.context, thisHook.context.embedOptions).then(function (result) {
+  iris.invokeHook("hook_entity_fetch", thisHook.authPass, thisHook.context.embedOptions, thisHook.context.embedOptions).then(function (result) {
 
     thisHook.context.vars[thisHook.context.embedID] = result;
 


### PR DESCRIPTION
Data object should be for the result of the query, not the query itself. That should be stored in context. That way it is available to all hooks in the chain. Should do this with other hooks as well, slowly moving over the initial hook call to use the context parameter rather than the data one.

This patch allows both methods for backwards compatibility.
