### PR TITLE
Add path field to every entity type

### DIFF
--- a/db.js
+++ b/db.js
@@ -223,7 +223,7 @@ iris.dbPopulate = function () {
       label: 'path',
       unique: true,
       fixed: true, // A fixed field isn't shown on the schema edit page as it can't be edited/deleted 
-      weight: Infinity,
+      weight: 1111, // JSON doesn't support infinity - ugh
       machineName: 'path'
     };
 

--- a/db.js
+++ b/db.js
@@ -1,6 +1,3 @@
-
-
-
 /**
  * @file Manages the database connection and schemas for entity types.
  *
@@ -213,6 +210,22 @@ iris.dbPopulate = function () {
   };
 
   Object.keys(iris.entityTypes).forEach(function (entityType) {
+
+    if (!iris.entityTypes[entityType].fields) {
+
+      iris.entityTypes[entityType].fields = {};
+
+    }
+
+    iris.entityTypes[entityType].fields.path = {
+      fieldType: 'Textfield',
+      fieldTypeType: 'String',
+      label: 'path',
+      unique: true,
+      fixed: true, // A fixed field isn't shown on the schema edit page as it can't be edited/deleted 
+      weight: Infinity,
+      machineName: 'path'
+    };
 
     iris.invokeHook("hook_db_schema__" + iris.config.dbEngine, "root", {
       schema: entityType,

--- a/db.js
+++ b/db.js
@@ -221,7 +221,6 @@ iris.dbPopulate = function () {
       fieldType: 'Textfield',
       fieldTypeType: 'String',
       label: 'path',
-      unique: true,
       fixed: true, // A fixed field isn't shown on the schema edit page as it can't be edited/deleted 
       weight: 1111, // JSON doesn't support infinity - ugh
       machineName: 'path'

--- a/modules/extra/entityUI/entityUI.js
+++ b/modules/extra/entityUI/entityUI.js
@@ -269,7 +269,7 @@ iris.modules.entityUI.registerHook("hook_form_render__entity", 0, function (this
         if (data.schema && data.schema.path) {
 
           data.schema.path.title = thisHook.authPass.t("Path");
-          data.schema.path.description = thisHook.authPass.t("Enter a path for the entity with a leading slash");
+          data.schema.path.description = thisHook.authPass.t("Enter a path for the entity. Leading / is required.");
 
         }
 

--- a/modules/extra/entityUI/entityUI.js
+++ b/modules/extra/entityUI/entityUI.js
@@ -144,12 +144,12 @@ iris.route.get("/:type/:id/delete", routes.delete, function (req, res) {
 
     });
 
-  }, function(fail){
-    
-     iris.modules.frontend.globals.displayErrorPage(404, req, res);
+  }, function (fail) {
 
-      return false;
-    
+    iris.modules.frontend.globals.displayErrorPage(404, req, res);
+
+    return false;
+
   });
 
 });
@@ -263,6 +263,15 @@ iris.modules.entityUI.registerHook("hook_form_render__entity", 0, function (this
       counter += 1;
 
       if (counter === fieldCount) {
+
+        // Change path field (on all entities) name and description
+
+        if (data.schema && data.schema.path) {
+
+          data.schema.path.title = thisHook.authPass.t("Path");
+          data.schema.path.description = thisHook.authPass.t("Enter a path for the entity with a leading slash");
+
+        }
 
         data.form.push("entityType");
 
@@ -704,6 +713,7 @@ iris.modules.entityUI.registerHook("hook_form_render__entity", 0, function (this
         }
 
         data.schema[fieldName] = form;
+
         fieldLoaded();
 
       }, editingEntity ? editingEntity[fieldName] : null, fieldName);

--- a/modules/extra/entityUI/schemaUI.js
+++ b/modules/extra/entityUI/schemaUI.js
@@ -597,24 +597,24 @@ iris.modules.entityUI.registerHook("hook_form_render__schemaFieldListing", 0, fu
 
       var recurseFields = function (object, elementParent) {
 
-          for (element in object) {
+        for (element in object) {
 
-            if (element == parent) {
+          if (element == parent) {
 
-              parentSchema = object[element];
-              fields = object[element].subfields;
+            parentSchema = object[element];
+            fields = object[element].subfields;
 
-              return;
+            return;
 
-            } else if (typeof object[element].fieldType != 'undefined' && object[element].fieldType == 'Fieldset') {
+          } else if (typeof object[element].fieldType != 'undefined' && object[element].fieldType == 'Fieldset') {
 
-              recurseFields(object[element].subfields, element);
-
-            }
+            recurseFields(object[element].subfields, element);
 
           }
-        };
-        // Do recursion to find the desired fields to list as they may be nested.
+
+        }
+      };
+      // Do recursion to find the desired fields to list as they may be nested.
       recurseFields(entityTypeSchema.fields, parent);
 
     } else {
@@ -636,6 +636,13 @@ iris.modules.entityUI.registerHook("hook_form_render__schemaFieldListing", 0, fu
         var field = JSON.parse(JSON.stringify(parentSchema.subfields[fieldName]));
       }
 
+      // Hide field if set to fixed (like path) as it shouldn't be able to be removed from the schema
+
+      if (field.fixed) {
+
+        return false;
+
+      }
 
       row['fieldLabel'] = field.label;
       row['fieldId'] = fieldName;
@@ -698,18 +705,18 @@ iris.modules.entityUI.registerHook("hook_form_render__schemaFieldListing", 0, fu
     });
     tableHtml += '</tbody></table>';
 
-    var displayFieldTypes = function(){
+    var displayFieldTypes = function () {
       var allowedFieldTypes = {};
-      for(var key in iris.fieldTypes){
-        if(!iris.fieldTypes[key].hidden){
+      for (var key in iris.fieldTypes) {
+        if (!iris.fieldTypes[key].hidden) {
           allowedFieldTypes[key] = iris.fieldTypes[key];
         }
       }
-       
+
       return Object.keys(allowedFieldTypes).concat(["Fieldset"]);
     };
-    
-    
+
+
     var weightFields = {
       "type": "array",
       "title": ap.t("weights"),


### PR DESCRIPTION
We currently have a strange usability issue where to add a path onto an entity a user has to:
- Add a text field
- Call it `path`
- Ignore most other field settings relating to textfields as it's not really one. Unique field acts in its own way for paths etc checking across all other entity types.

Every entity already has a dynamic path at `/entitytype/eid` and entities have access permissions so it seems to make no sense to have the path field as a reserved word and not put it in every schema automatically.

It doesn't have to be used but this makes the process make a lot more sense.
