### PR TITLE
Move websocket sessions into hook_system_ready

### DIFF
--- a/modules/core/websockets/websockets.js
+++ b/modules/core/websockets/websockets.js
@@ -16,8 +16,12 @@ iris.socketListeners = {};
 
 iris.socketServer = io(iris.server);
 
-iris.socketServer.use(function (socket, next) {
-  iris.sessions(socket.handshake, {}, next);
+iris.modules.websockets.registerHook("hook_system_ready", 0, function (thisHook, data) {
+
+  iris.socketServer.use(function (socket, next) {
+    iris.sessions(socket.handshake, {}, next);
+  });
+
 });
 
 /**


### PR DESCRIPTION
Makes websocket session initialisation wait until server is ready.
