### PR TITLE
Consistent embed name

### DIFF
--- a/modules/core/email/templates/mail-settings.html
+++ b/modules/core/email/templates/mail-settings.html
@@ -1,1 +1,1 @@
-{{{iris 'form' '{"formID":"mailSettings"}'}}}
+{{{iris 'form' '{"name":"mailSettings"}'}}}

--- a/modules/core/forms/embed.js
+++ b/modules/core/forms/embed.js
@@ -106,9 +106,17 @@ var renderForm = function (formName, formParams, form, authPass, callback, req) 
  */
 iris.modules.forms.registerHook("hook_frontend_embed__form", 0, function (thisHook, data) {
 
-  if (!thisHook.context.embedOptions.formID) {
+  if (thisHook.context.embedOptions.formID) {
 
-    thisHook.fail("No formID");
+    console.log('"formid" embed parameter has been changed to "name". You should change the template embed code for form "' + thisHook.context.embedOptions.formID + '"');
+
+    thisHook.context.embedOptions.name = thisHook.context.embedOptions.formID;
+
+  }
+
+  if (!thisHook.context.embedOptions.name) {
+
+    thisHook.fail("No form name");
 
     return false;
 
@@ -183,7 +191,7 @@ iris.modules.forms.registerHook("hook_frontend_embed__form", 0, function (thisHo
 
   var formParams = thisHook.context.embedOptions;
 
-  var formName = thisHook.context.embedOptions.formID;
+  var formName = thisHook.context.embedOptions.name;
   thisHook.context.embedID = formName;
 
   var formTemplate = {

--- a/modules/core/forms/embed.js
+++ b/modules/core/forms/embed.js
@@ -111,6 +111,8 @@ iris.modules.forms.registerHook("hook_frontend_embed__form", 0, function (thisHo
     console.log('"formid" embed parameter has been changed to "name". You should change the template embed code for form "' + thisHook.context.embedOptions.formID + '"');
 
     thisHook.context.embedOptions.name = thisHook.context.embedOptions.formID;
+    
+    delete thisHook.context.embedOptions.formID;
 
   }
 

--- a/modules/core/frontend/frontend.js
+++ b/modules/core/frontend/frontend.js
@@ -471,7 +471,7 @@ iris.modules.frontend.registerHook("hook_frontend_embed__template", 0, function 
 
   if (thisHook.context.embedOptions.template) {
 
-    console.log('"formid" embed parameter has been changed to "name". You should change the template embed code for form "' + thisHook.context.embedOptions.formID + '"');
+    console.log('"template" embed parameter has been changed to "name". You should change the template embed code for template "' + thisHook.context.embedOptions.template + '"');
 
     thisHook.context.embedOptions.name = thisHook.context.embedOptions.template;
 

--- a/modules/core/frontend/frontend.js
+++ b/modules/core/frontend/frontend.js
@@ -469,11 +469,19 @@ var merge = require("merge");
 
 iris.modules.frontend.registerHook("hook_frontend_embed__template", 0, function (thisHook, data) {
 
-  // Split embed code by double underscores
-
   if (thisHook.context.embedOptions.template) {
 
-    var searchArray = thisHook.context.embedOptions.template.split("__");
+    console.log('"formid" embed parameter has been changed to "name". You should change the template embed code for form "' + thisHook.context.embedOptions.formID + '"');
+
+    thisHook.context.embedOptions.name = thisHook.context.embedOptions.template;
+
+  }
+
+  if (thisHook.context.embedOptions.name) {
+
+    // Split embed code by double underscores
+
+    var searchArray = thisHook.context.embedOptions.name.split("__");
 
     // Get template
 
@@ -483,7 +491,7 @@ iris.modules.frontend.registerHook("hook_frontend_embed__template", 0, function 
 
     }, function (fail) {
 
-      iris.log("error", "Tried to embed template " + thisHook.context.embedOptions.template + " but no matching template file found.");
+      iris.log("error", "Tried to embed template " + thisHook.context.embedOptions.name + " but no matching template file found.");
 
       thisHook.pass("");
 

--- a/modules/core/frontend/frontend.js
+++ b/modules/core/frontend/frontend.js
@@ -475,6 +475,8 @@ iris.modules.frontend.registerHook("hook_frontend_embed__template", 0, function 
 
     thisHook.context.embedOptions.name = thisHook.context.embedOptions.template;
 
+    delete thisHook.context.embedOptions.template;
+
   }
 
   if (thisHook.context.embedOptions.name) {

--- a/modules/core/frontend/templates/403.html
+++ b/modules/core/frontend/templates/403.html
@@ -23,7 +23,7 @@
 
       <p>You don't have permission to access this page.</p>
       
-      {{{iris 'form' '{"formID":"login"}'}}}
+      {{{iris 'form' '{"name":"login"}'}}}
       
     </div>
 

--- a/modules/core/menu/menu.js
+++ b/modules/core/menu/menu.js
@@ -20,6 +20,8 @@ iris.modules.menu.registerHook("hook_frontend_embed__menu", 0, function (thisHoo
     console.log('"menu" embed parameter has been changed to "name". You should change the template embed code for menu "' + thisHook.context.embedOptions.menu + '"');
 
     thisHook.context.embedOptions.name = thisHook.context.embedOptions.menu;
+    
+    delete thisHook.context.embedOptions.menu;
 
   }
 

--- a/modules/core/menu/menu.js
+++ b/modules/core/menu/menu.js
@@ -6,7 +6,7 @@
  * @namespace menu
  */
 
-iris.registerModule("menu",__dirname);
+iris.registerModule("menu", __dirname);
 
 /**
  * Embed function for [[[menu __]]] embeds.
@@ -15,8 +15,16 @@ iris.registerModule("menu",__dirname);
 
 iris.modules.menu.registerHook("hook_frontend_embed__menu", 0, function (thisHook, data) {
 
-  var menuName = thisHook.context.embedOptions.menu;
+  if (thisHook.context.embedOptions.menu) {
 
+    console.log('"menu" embed parameter has been changed to "name". You should change the template embed code for menu "' + thisHook.context.embedOptions.menu + '"');
+
+    thisHook.context.embedOptions.name = thisHook.context.embedOptions.menu;
+
+  }
+
+  var menuName = thisHook.context.embedOptions.name;
+  
   var menuItems = [];
 
   var embedOptions = thisHook.context.embedOptions;
@@ -32,7 +40,7 @@ iris.modules.menu.registerHook("hook_frontend_embed__menu", 0, function (thisHoo
         // Route has a menu
 
         route.options.menu.forEach(function (menu) {
-          
+
           if (menu.menuName === menuName) {
 
             if (!menu.weight) {
@@ -55,7 +63,7 @@ iris.modules.menu.registerHook("hook_frontend_embed__menu", 0, function (thisHoo
     }
 
   });
-  
+
   // Order by path
 
   menuItems.sort(function (a, b) {
@@ -95,8 +103,8 @@ iris.modules.menu.registerHook("hook_frontend_embed__menu", 0, function (thisHoo
       var found = false;
       for (var i = 0; i < arr.length; i++) {
         if (arr[i] && (arr[i].path == item.path)) {
-           found = true;
-           break;
+          found = true;
+          break;
         }
       }
       return found;
@@ -112,20 +120,17 @@ iris.modules.menu.registerHook("hook_frontend_embed__menu", 0, function (thisHoo
                 data.children.push(item);
               }
 
-            }
-            else {
+            } else {
               data.children = [item];
 
             }
-          }
-          else {
+          } else {
             if (data.children && data.children.length) {
               findParent(data.children, item);
             }
           }
         });
-      }
-      else {
+      } else {
 
         if (!isItemExist(menu, item)) {
           menu.push(item);
@@ -161,9 +166,9 @@ iris.modules.menu.registerHook("hook_frontend_embed__menu", 0, function (thisHoo
 
   };
 
-  var recursiveSort = function(menu) {
+  var recursiveSort = function (menu) {
 
-    menu.forEach(function(item) {
+    menu.forEach(function (item) {
 
       if (item.children) {
 
@@ -326,6 +331,6 @@ iris.modules.menu.registerHook("hook_frontend_handlebars_extend", 1, function (t
     thisHook.pass(Handlebars);
   });
 
-  
+
 
 });

--- a/modules/core/system/templates/admin_login.html
+++ b/modules/core/system/templates/admin_login.html
@@ -4,7 +4,7 @@
   <div id="login-logo">Iris</div>
   <div id="login-form">
     <h1>Sign in</h1>
-      {{{iris 'form' '{"formID":"login"}'}}}
+      {{{iris 'form' '{"name":"login"}'}}}
   </div>
 
 </section>

--- a/modules/core/system/templates/admin_modules.html
+++ b/modules/core/system/templates/admin_modules.html
@@ -1,1 +1,1 @@
-{{{iris 'form' '{"formID":"modules"}'}}}
+{{{iris 'form' '{"name":"modules"}'}}}

--- a/modules/core/system/templates/admin_restart.html
+++ b/modules/core/system/templates/admin_restart.html
@@ -2,6 +2,6 @@
 
 <div class="no-fieldset-bg">
 
-{{{iris 'form' '{"formID":"restart"}'}}}
+{{{iris 'form' '{"name":"restart"}'}}}
 
 </div>

--- a/modules/core/system/templates/admin_themes.html
+++ b/modules/core/system/templates/admin_themes.html
@@ -1,1 +1,1 @@
-{{{iris 'form' '{"formID":"themes"}'}}}
+{{{iris 'form' '{"name":"themes"}'}}}

--- a/modules/core/system/templates/admin_wrapper.html
+++ b/modules/core/system/templates/admin_wrapper.html
@@ -19,7 +19,7 @@
 
   <section class="col-sm-2" id="admin_sidebar">
     
-  {{{iris 'menu' '{"menu":"admin_toolbar","template":"admin_sidebar"}'}}}
+  {{{iris 'menu' '{"name":"admin_toolbar","template":"admin_sidebar"}'}}}
     
   </section>
   <section class="col-sm-10 col-sm-offset-2" id="main_content">

--- a/modules/core/user/templates/first_user.html
+++ b/modules/core/user/templates/first_user.html
@@ -6,4 +6,4 @@
 
 <h1>Set up your root admin account</h1>
 
-{{{iris 'form' '{"formID":"set_first_user"}'}}}
+{{{iris 'form' '{"name":"set_first_user"}'}}}

--- a/modules/core/user/templates/login.html
+++ b/modules/core/user/templates/login.html
@@ -2,6 +2,6 @@
 
 <section id="login-page">
   <div id="login-form">
-{{{iris 'form' '{"formID":"login"}'}}}
+{{{iris 'form' '{"name":"login"}'}}}
   </div>
 </section>

--- a/modules/core/user/templates/passwordReset.html
+++ b/modules/core/user/templates/passwordReset.html
@@ -2,6 +2,6 @@
 
 <section id="login-page">
   <div id="login-form">
-    {{{iris 'form' '{"formID":"passwordReset"}'}}}
+    {{{iris 'form' '{"name":"passwordReset"}'}}}
   </div>
 </section>

--- a/modules/extra/autopath/templates/admin_autopath.html
+++ b/modules/extra/autopath/templates/admin_autopath.html
@@ -2,6 +2,6 @@
 
 <h2>{{this}}</h2>
 
-{{{iris embed="form" formID="autopath" entityType=this}}}
+{{{iris embed="form" name="autopath" entityType=this}}}
 
 {{/each}}

--- a/modules/extra/blocks/templates/admin_blockdelete.html
+++ b/modules/extra/blocks/templates/admin_blockdelete.html
@@ -1,4 +1,4 @@
 <div class="admin-header admin-header-padding">Delete Schema: {{entityType}}</div>
 
-{{{iris 'form' '{"formID":"blockDeleteForm","blockType":"$blocktype","blockID":"$blockid"}'}}}
+{{{iris 'form' '{"name":"blockDeleteForm","blockType":"$blocktype","blockID":"$blockid"}'}}}
 

--- a/modules/extra/blocks/templates/admin_blockform.html
+++ b/modules/extra/blocks/templates/admin_blockform.html
@@ -2,12 +2,12 @@
 
   <div class="admin-header admin-header-padding">Editing {{blocktype}} {{blockid}}</div>
 
-  {{{iris 'form' '{"formID":"blockForm_$blocktype","blockID":"$blockid"}'}}}
+  {{{iris 'form' '{"name":"blockForm_$blocktype","blockID":"$blockid"}'}}}
 
 {{else}}
 
   <div class="admin-header admin-header-padding">Creating new {{blocktype}}</div>
  
-  {{{iris 'form' '{"formID":"blockForm_$blocktype"}'}}}
+  {{{iris 'form' '{"name":"blockForm_$blocktype"}'}}}
 
 {{/if}}

--- a/modules/extra/blocks/templates/admin_blockslist.html
+++ b/modules/extra/blocks/templates/admin_blockslist.html
@@ -21,7 +21,7 @@
 
   {{#if blockTypes}}
 
-    {{{iris 'form' '{"formID":"newBlockForm"}'}}}
+    {{{iris 'form' '{"name":"newBlockForm"}'}}}
 
   {{else}}
 

--- a/modules/extra/entityUI/templates/admin_entity.html
+++ b/modules/extra/entityUI/templates/admin_entity.html
@@ -1,9 +1,9 @@
 {{#if eid}}
   
-{{{iris 'form' '{"formID":"entity","eid":$eid,"entityType":"$type"}'}}}
+{{{iris 'form' '{"name":"entity","eid":$eid,"entityType":"$type"}'}}}
 
 {{else}}
   
-{{{iris 'form' '{"formID":"entity","entityType":"$type"}'}}}
+{{{iris 'form' '{"name":"entity","entityType":"$type"}'}}}
   
 {{/if}}

--- a/modules/extra/entityUI/templates/admin_entity_delete.html
+++ b/modules/extra/entityUI/templates/admin_entity_delete.html
@@ -1,3 +1,3 @@
 {{text}}
 
-{{{iris 'form' '{"formID":"entity_delete","eid":$id,"entityType":"$type"}'}}}
+{{{iris 'form' '{"name":"entity_delete","eid":$id,"entityType":"$type"}'}}}

--- a/modules/extra/entityUI/templates/admin_schema.html
+++ b/modules/extra/entityUI/templates/admin_schema.html
@@ -25,7 +25,7 @@
   <div id="current-fields">
     
 
-      {{{iris 'form' '{"formID":"schema","entityType":"$entityType","existing":true}'}}}
+      {{{iris 'form' '{"name":"schema","entityType":"$entityType","existing":true}'}}}
 
   </div>
 
@@ -35,7 +35,7 @@
 
   <div class="admin-header admin-header-padding">Create A New Schema</div>
   
-  {{{iris 'form' '{"formID":"schema","existing":false}'}}}
+  {{{iris 'form' '{"name":"schema","existing":false}'}}}
 
 </div>
 

--- a/modules/extra/entityUI/templates/admin_schema_delete.html
+++ b/modules/extra/entityUI/templates/admin_schema_delete.html
@@ -24,7 +24,7 @@
 
   <div id="current-fields">
     
-      {{{iris 'form' '{"formID":"schemaDelete","entityType":"$entityType"}'}}}
+      {{{iris 'form' '{"name":"schemaDelete","entityType":"$entityType"}'}}}
 
   </div>
 

--- a/modules/extra/entityUI/templates/admin_schema_field.html
+++ b/modules/extra/entityUI/templates/admin_schema_field.html
@@ -1,9 +1,9 @@
 {{#if parent}}
 
-{{{iris 'form' '{"formID":"schemafield","entityType":"$entityType","field":"$field","parent":"$parent"}'}}}
+{{{iris 'form' '{"name":"schemafield","entityType":"$entityType","field":"$field","parent":"$parent"}'}}}
 
 {{else}}
 
-{{{iris 'form' '{"formID":"schemafield","entityType":"$entityType","field":"$field"}'}}}
+{{{iris 'form' '{"name":"schemafield","entityType":"$entityType","field":"$field"}'}}}
 
 {{/if}}

--- a/modules/extra/entityUI/templates/admin_schema_field_delete.html
+++ b/modules/extra/entityUI/templates/admin_schema_field_delete.html
@@ -1,1 +1,1 @@
-{{{iris 'form' '{"formID":"schemafieldDelete","entityType":"$entityType","field":"$field"}'}}}
+{{{iris 'form' '{"name":"schemafieldDelete","entityType":"$entityType","field":"$field"}'}}}

--- a/modules/extra/entityUI/templates/admin_schema_field_widget.html
+++ b/modules/extra/entityUI/templates/admin_schema_field_widget.html
@@ -1,9 +1,9 @@
 {{#if parent}}
 
-{{{iris 'form' '{"formID":"schemafieldwidgets","entityType":"$entityType","field":"$field","parent":"$parent"}'}}}
+{{{iris 'form' '{"name":"schemafieldwidgets","entityType":"$entityType","field":"$field","parent":"$parent"}'}}}
 
 {{else}}
 
-{{{iris 'form' '{"formID":"schemafieldwidgets","entityType":"$entityType","field":"$field"}'}}}
+{{{iris 'form' '{"name":"schemafieldwidgets","entityType":"$entityType","field":"$field"}'}}}
 
 {{/if}}

--- a/modules/extra/entityUI/templates/admin_schema_manage_fields.html
+++ b/modules/extra/entityUI/templates/admin_schema_manage_fields.html
@@ -40,11 +40,11 @@
   
   {{#if parent}}
   
-  {{{iris 'form' '{"formID":"schemaFieldListing","entityType":"$entityType","parent":"$parent"}'}}}
+  {{{iris 'form' '{"name":"schemaFieldListing","entityType":"$entityType","parent":"$parent"}'}}}
   
   {{else}}
   
-    {{{iris 'form' '{"formID":"schemaFieldListing","entityType":"$entityType"}'}}}
+    {{{iris 'form' '{"name":"schemaFieldListing","entityType":"$entityType"}'}}}
   
   {{/if}}
 

--- a/modules/extra/ip_access/templates/admin_ip_access.html
+++ b/modules/extra/ip_access/templates/admin_ip_access.html
@@ -1,2 +1,2 @@
-{{{iris 'form' '{"formID":"ip_access"}'}}}
+{{{iris 'form' '{"name":"ip_access"}'}}}
 

--- a/modules/extra/menu_block/menu_block.js
+++ b/modules/extra/menu_block/menu_block.js
@@ -24,7 +24,7 @@ iris.modules.menu_block.registerHook("hook_block_render", 0, function (thisHook,
 
     var config = thisHook.context.config;
 
-    thisHook.pass("{{{iris embed='menu' menu='" + config.menu + "'}}}");
+    thisHook.pass("{{{iris embed='menu' name='" + config.menu + "'}}}");
 
   } else {
 

--- a/modules/extra/menu_ui/menu_ui.js
+++ b/modules/extra/menu_ui/menu_ui.js
@@ -1,4 +1,3 @@
-
 var routes = {
   menu: {
     title: "Menu Listing",
@@ -18,7 +17,15 @@ var routes = {
 
 iris.modules.menu_ui.registerHook("hook_frontend_embed__menu", 2, function (thisHook, data) {
 
-  var menuName = thisHook.context.embedOptions.menu;
+  if (thisHook.context.embedOptions.menu) {
+
+    console.log('"menu" embed parameter has been changed to "name". You should change the template embed code for menu "' + thisHook.context.embedOptions.menu + '"');
+
+    thisHook.context.embedOptions.name = thisHook.context.embedOptions.menu;
+
+  }
+
+  var menuName = thisHook.context.embedOptions.name;
 
   iris.readConfig('menu', menuName).then(function (config) {
 
@@ -61,9 +68,9 @@ iris.modules.menu_ui.registerHook("hook_form_render__menu", 0, function (thisHoo
 
   // Check if menu name supplied and previous values available
   var ap = thisHook.authPass;
-  
+
   var menuId = thisHook.context.params.menuName;
-  
+
   iris.readConfig('menu', menuId).then(function (config) {
 
     data.value = config;

--- a/modules/extra/menu_ui/templates/admin_menu_form.html
+++ b/modules/extra/menu_ui/templates/admin_menu_form.html
@@ -1,6 +1,6 @@
 <div class="admin-inputs">
   <div class="admin-header admin-header-padding">Create new menu</div>
 
-{{{iris 'form' '{"formID":"menu"}'}}}
+{{{iris 'form' '{"name":"menu"}'}}}
   
 </div>

--- a/modules/extra/menu_ui/templates/admin_menu_form_delete.html
+++ b/modules/extra/menu_ui/templates/admin_menu_form_delete.html
@@ -1,3 +1,3 @@
 <h2>Delete menu {{menuName}}</h2>
 
-{{{iris 'form' '{"formID":"menu_delete","menuName":"$menuName"}'}}}
+{{{iris 'form' '{"name":"menu_delete","menuName":"$menuName"}'}}}

--- a/modules/extra/menu_ui/templates/admin_menu_form_edit.html
+++ b/modules/extra/menu_ui/templates/admin_menu_form_edit.html
@@ -1,3 +1,3 @@
 <h1>Edit menu {{menuName}}</h1>
 
-{{{iris 'form' '{"formID":"menu","menuName":"$menuName"}'}}}
+{{{iris 'form' '{"name":"menu","menuName":"$menuName"}'}}}

--- a/modules/extra/permissionsUI/templates/admin_permissions.html
+++ b/modules/extra/permissionsUI/templates/admin_permissions.html
@@ -1,3 +1,3 @@
 <div class="admin-header admin-header-padding">Permissions</div>
 
-{{{iris 'form' '{"formID":"permissions"}'}}}
+{{{iris 'form' '{"name":"permissions"}'}}}

--- a/modules/extra/regions/templates/admin_regions.html
+++ b/modules/extra/regions/templates/admin_regions.html
@@ -1,6 +1,6 @@
 <div class="admin-inputs">
   <div class="admin-header admin-header-padding">Blocks and regions</div>
 
-{{{iris 'form' '{"formID":"regions"}'}}}
+{{{iris 'form' '{"name":"regions"}'}}}
   
 </div>

--- a/modules/extra/roles_ui/templates/administer-roles.html
+++ b/modules/extra/roles_ui/templates/administer-roles.html
@@ -1,4 +1,4 @@
 <div class="admin-inputs" class="no-fieldset-bg">
   <div class="admin-header admin-header-padding">Adminsiter roles</div>
-{{{iris 'form' '{"formID":"manageRoles"}'}}}
+{{{iris 'form' '{"name":"manageRoles"}'}}}
 </div>

--- a/modules/extra/textfilters/templates/admin_textfilters_delete.html
+++ b/modules/extra/textfilters/templates/admin_textfilters_delete.html
@@ -1,1 +1,1 @@
-{{{iris 'form' '{"formID":"textfilter_delete","formatName":"$formatname"}'}}}
+{{{iris 'form' '{"name":"textfilter_delete","formatName":"$formatname"}'}}}

--- a/modules/extra/textfilters/templates/admin_textfilters_form.html
+++ b/modules/extra/textfilters/templates/admin_textfilters_form.html
@@ -1,9 +1,9 @@
 {{#if formatname}}
 
-{{{iris 'form' '{"formID":"textfilter","formatname":"$formatname"}'}}}
+{{{iris 'form' '{"name":"textfilter","formatname":"$formatname"}'}}}
 
 {{else}}
 
-{{{iris 'form' '{"formID":"textfilter"}'}}}
+{{{iris 'form' '{"name":"textfilter"}'}}}
 
 {{/if}}

--- a/modules/extra/triggers/templates/admin_triggers_delete.html
+++ b/modules/extra/triggers/templates/admin_triggers_delete.html
@@ -1,2 +1,2 @@
-{{{iris 'form' '{"formID":"action_delete","action":"$action"}'}}}
+{{{iris 'form' '{"name":"action_delete","action":"$action"}'}}}
 

--- a/modules/extra/triggers/templates/admin_triggers_form.html
+++ b/modules/extra/triggers/templates/admin_triggers_form.html
@@ -3,11 +3,11 @@
 
 {{#if action}}
 
-{{{iris 'form' '{"formID":"actions","action":"$action"}'}}}
+{{{iris 'form' '{"name":"actions","action":"$action"}'}}}
 
 {{else}}
 
-{{{iris 'form' '{"formID":"actions"}'}}}
+{{{iris 'form' '{"name":"actions"}'}}}
 
 {{/if}}
 

--- a/readme.md
+++ b/readme.md
@@ -268,7 +268,7 @@ Forms each need a formID parameter. Any other parameters will be passed into the
 
 ```HTML
 
-{{{iris embed="form" formID="login"}}}
+{{{iris embed="form" name="login"}}}
 
 ```
 
@@ -278,7 +278,7 @@ Menus take a `menu` parameter and an optional `template` parameter that can over
 
 ```HTML
 
-{{{iris embed='menu' menu="admin_toolbar"}}}
+{{{iris embed='menu' name="admin_toolbar"}}}
 
 ```
 
@@ -288,7 +288,7 @@ Template embeds simply take the template lookup you want to use to embed a templ
 
 ```HTML
 
-{{{iris embed='template' template="sidebar"}}}
+{{{iris embed='template' name="sidebar"}}}
 
 ```
 


### PR DESCRIPTION
Core embeds all now use the "name" parameter where needed instead of their own take on it.

`formID` becomes `name`
`menu` becomes `name`
`template` becomes `name`

To make converting easier I've put in code if you use the wrong one that automatically fixes it but prints a notice.

All core stuff has been converted.
