### PR TITLE
Allow for overridable permissions

### DIFF
--- a/modules/core/auth/auth.js
+++ b/modules/core/auth/auth.js
@@ -564,7 +564,6 @@ iris.modules.auth.registerHook("hook_request_intercept", 0, function (thisHook, 
     }
     else {
 
-      console.log('paddeeded');
       thisHook.pass(data);
 
     }

--- a/modules/core/auth/auth.js
+++ b/modules/core/auth/auth.js
@@ -540,11 +540,7 @@ iris.modules.auth.registerHook("hook_request_intercept", 0, function (thisHook, 
 
   // Check if a matching route is found
 
-  if (thisHook.context.req.irisRoute && thisHook.context.req.irisRoute.options && thisHook.context.req.irisRoute.options.permissions) {
-
-    var permissions = thisHook.context.req.irisRoute.options.permissions;
-
-    var access = iris.modules.auth.globals.checkPermissions(permissions, thisHook.context.req.authPass);
+  var actOnResult = function(access) {
 
     if (!access) {
 
@@ -565,11 +561,32 @@ iris.modules.auth.registerHook("hook_request_intercept", 0, function (thisHook, 
 
       });
 
-    } else {
+    }
+    else {
 
+      console.log('paddeeded');
       thisHook.pass(data);
 
     }
+
+  };
+
+  if (thisHook.context.req.irisRoute && thisHook.context.req.irisRoute.options && thisHook.context.req.irisRoute.options.permissionsCallback) {
+
+    if (typeof thisHook.context.req.irisRoute.options.permissionsCallback == 'function') {
+
+      thisHook.context.req.irisRoute.options.permissionsCallback(thisHook.context.req, actOnResult);
+
+    }
+
+  }
+  else if (thisHook.context.req.irisRoute && thisHook.context.req.irisRoute.options && thisHook.context.req.irisRoute.options.permissions) {
+
+    var permissions = thisHook.context.req.irisRoute.options.permissions;
+
+    var access = iris.modules.auth.globals.checkPermissions(permissions, thisHook.context.req.authPass);
+
+    actOnResult(access);
 
   } else {
 

--- a/modules/core/entity/entity_fetch.js
+++ b/modules/core/entity/entity_fetch.js
@@ -319,7 +319,7 @@ iris.modules.entity.registerHook("hook_entity_fetch", 0, function (thisHook, fet
 
         iris.invokeHook("hook_entity_view", thisHook.authPass, null, entities[_id]).then(function (viewChecked) {
 
-          if (viewChecked === undefined) {
+          if (viewChecked.access === false) {
             no("permission denied");
             return false;
           }
@@ -538,7 +538,7 @@ iris.modules.entity.registerHook("hook_entity_view", 0, function (thisHook, enti
   if (!viewAny && !(isOwn && viewOwn)) {
 
     //Can't view any of this type, delete it
-    entity = undefined;
+    entity.access = false;
 
   }
 


### PR DESCRIPTION
The route permissionsCallback is described here: https://github.com/CityWebConsultants/Iris/pull/124

The entity change simply adds entity.access = false instead of entity = undefined.

This means anyone can hook into this and remove the access = false if they want to allow permission that was previous revoked. Or add access = false if they want to restrict access even though core permissions granted it