### PR TITLE
Further extend permissions for added flexibility

### DIFF
--- a/modules/core/auth/auth.js
+++ b/modules/core/auth/auth.js
@@ -197,47 +197,51 @@ iris.modules.auth.globals = {
 
   checkPermissions: function (permissionsArray, authPass) {
 
-    var fs = require('fs'),
-      permissions;
-
-    //Load in permissions if available
-
-    try {
-      var currentPermissions = fs.readFileSync(iris.sitePath + "/configurations/auth/permissions.json", "utf8");
-
-      permissions = JSON.parse(currentPermissions);
-
-    } catch (e) {
-
-      permissions = {};
-
-    }
-
-    var access = false;
-
-    permissionsArray.forEach(function (permission) {
-
-      authPass.roles.forEach(function (role) {
-
-        if (permissions[permission] && permissions[permission].indexOf(role) !== -1) {
-
-          access = true;
-
-        }
-
-      });
-
-    });
-
     if (authPass.roles.indexOf("admin") >= 0) {
 
       access = true;
+
+    }
+    else {
+      var fs = require('fs'),
+        permissions;
+
+      //Load in permissions if available
+
+      try {
+        var currentPermissions = fs.readFileSync(iris.sitePath + "/configurations/auth/permissions.json", "utf8");
+
+        permissions = JSON.parse(currentPermissions);
+
+      }
+      catch (e) {
+
+        permissions = {};
+
+      }
+
+      var access = false;
+
+      permissionsArray.forEach(function (permission) {
+
+        authPass.roles.forEach(function (role) {
+
+          if (permissions[permission] && permissions[permission].indexOf(role) !== -1) {
+
+            access = true;
+
+          }
+
+        });
+
+      });
 
     }
 
     return access;
 
   }
+
 };
 
 iris.modules.auth.globals.registerPermission("can make access token", "auth");

--- a/modules/core/entity/entity_edit.js
+++ b/modules/core/entity/entity_edit.js
@@ -254,7 +254,6 @@ iris.modules.entity.registerHook("hook_entity_edit", 0, function (thisHook, data
 
     }, function (fail) {
 
-      console.log(fail);
       thisHook.fail(fail);
 
     });
@@ -303,7 +302,8 @@ iris.modules.entity.registerHook("hook_entity_access_edit", 0, function (thisHoo
     var viewAny = iris.modules.auth.globals.checkPermissions(["can edit any " + entity.entityType], thisHook.authPass);
     if (!viewAny && !(isOwn && viewOwn)) {
 
-      thisHook.fail("Access denied");
+      entity.access = false;
+      thisHook.pass(entity);
       return false;
 
     }

--- a/modules/core/entity/entity_fetch.js
+++ b/modules/core/entity/entity_fetch.js
@@ -429,7 +429,7 @@ iris.modules.entity.registerHook("hook_entity_fetch", 0, function (thisHook, fet
 
     }, function (fail) {
 
-      thisHook.fail("Fetch failed");
+      thisHook.fail("Fetch failed: " + fail);
 
     });
 

--- a/modules/core/forms/embed.js
+++ b/modules/core/forms/embed.js
@@ -222,7 +222,7 @@ iris.modules.forms.registerHook("hook_frontend_embed__form", 0, function (thisHo
 
     }, function (fail) {
 
-      thisHook.fail();
+      thisHook.fail(fail);
 
     });
 

--- a/modules/core/frontend/handlebars_helpers.js
+++ b/modules/core/frontend/handlebars_helpers.js
@@ -471,11 +471,11 @@ iris.modules.frontend.registerHook("hook_frontend_handlebars_extend", 0, functio
 
             pass(result);
 
-          }, function (fail) {
+          }, function (reason) {
 
-            iris.log("error", fail);
+            iris.log("error", reason);
 
-            pass("");
+            fail(reason);
 
           });
 
@@ -487,11 +487,11 @@ iris.modules.frontend.registerHook("hook_frontend_handlebars_extend", 0, functio
 
           pass(result);
 
-        }, function (fail) {
+        }, function (reason) {
 
-          iris.log("error", fail);
+          iris.log("error", reason);
 
-          pass("");
+          fail(reason);
 
         });
 

--- a/modules/extra/entityUI/entityUI.js
+++ b/modules/extra/entityUI/entityUI.js
@@ -54,7 +54,16 @@ iris.route.get("/:type/:eid/edit", function (req, res) {
 
   }, function (fail) {
 
-    iris.modules.frontend.globals.displayErrorPage(500, req, res);
+    if (fail === 'Fetch failed: permission denied') {
+
+      iris.modules.frontend.globals.displayErrorPage(403, req, res);
+
+    }
+    else {
+
+      iris.modules.frontend.globals.displayErrorPage(500, req, res);
+
+    }
 
     iris.log("error", fail);
 
@@ -745,6 +754,10 @@ iris.modules.entityUI.registerHook("hook_form_render__entity", 0, function (this
         renderFields(doc[0]);
 
       }
+
+    }, function(fail) {
+
+      thisHook.fail(fail);
 
     });
 


### PR DESCRIPTION
Essentially, these alterations allow for custom logic during the entity edit render process to determine how the original page request responds.

if any hook fails throughout the process, this should filter all the way back up to the originally called hook so that it can respond in different ways.

In my particular use-case, we need custom logic to determine which individual users can edit individual entities which cannot be covered by the static core permissions. If the logic determines it can even though core perms say it cant then the entity form should render and submit. Equally, if core perms say it should but the logic says says it shouldn't then the 403 response should be sent.
