### PR TITLE
Expose iris object to parent calling file

### DIFF
--- a/boot.js
+++ b/boot.js
@@ -335,6 +335,12 @@ module.exports = function (config) {
 
   });
 
+  // Require launching file for user defined hooks etc but stop it creating a feedback loop.
+
+  process.running = true;
+
+  require(config.launchFile);
+
   iris.mkdirSync(iris.sitePath + "/" + "local");
 
   fs.writeFileSync(iris.sitePath + "/local/modulePathCache.json", JSON.stringify(foundModules));


### PR DESCRIPTION
Instead of returning undefined, this makes the require("iris") function return a promise that resolves to the actual Iris object of the instance. This is done through re-requiring the file that called it (but stopping a feedback loop from developing).

This is potentially very powerful and might make Iris projects a lot easier to manage (especially the module system).

So you can do stuff like:

```JavaScript 

require("irisjs")({
  // Normal config
}).then(function (iris) {

  // Modules, hooks etc can all be defined and required here like a normal node.js project

})

```

The only new bit is the promise at the end. This pull request shouldn't break any existing code (fingers crossed).

Was planning to do this as part of a major version refactor of lots of core code but it's actually been quite simple to slot in.

Have a play with it. Thoughts and feedback welcome.