### PR TITLE
Get previous hook in chain's filename

### DIFF
--- a/hook.js
+++ b/hook.js
@@ -22,6 +22,7 @@
 
 // Debug functions storing last hooks
 
+
 iris.hookStack = [];
 
 var storeHook = function (hook) {
@@ -108,7 +109,8 @@ var hook = function (hookname, authPass, staticVariables, variables) {
           event: moduleHooks[hookname].event,
           parentModule: element,
           name: hookname,
-          rank: moduleHooks[hookname].rank
+          rank: moduleHooks[hookname].rank,
+          registration: moduleHooks[hookname].registration
 
         };
 
@@ -181,6 +183,12 @@ var hook = function (hookname, authPass, staticVariables, variables) {
           thisHook.path = hookcall.parentModule;
           thisHook.rank = hookcall.rank;
           thisHook.index = index;
+
+          if (hookcalls[index - 1]) {
+
+            thisHook.previousHook = hookcalls[index - 1].registration
+
+          }
 
           try {
             hookcall.event(thisHook, vars);

--- a/modules.js
+++ b/modules.js
@@ -1,11 +1,35 @@
 
-
-
 /**
  * @file Base for the module system. Provides functions for module registration and management.
  */
 
 iris.modules = {};
+
+// Function to get the caller file, used for listing the previous hook in a hook chain
+
+function getCaller() {
+    var originalFunc = Error.prepareStackTrace;
+
+    var callerfile;
+    try {
+        var err = new Error();
+        var currentfile;
+
+        Error.prepareStackTrace = function (err, stack) { return stack; };
+
+        currentfile = err.stack.shift().getFileName();
+
+        while (err.stack.length) {
+            callerfile = err.stack.shift().getFileName();
+
+            if(currentfile !== callerfile) break;
+        }
+    } catch (e) {}
+
+    Error.prepareStackTrace = originalFunc; 
+
+    return callerfile;
+}
 
 var moduleTemplate = (function () {
 
@@ -45,7 +69,6 @@ var moduleTemplate = (function () {
           iris.socketListeners[name] = [];
 
         }
-
         iris.socketListeners[name].push(callback);
 
       } else {
@@ -56,7 +79,8 @@ var moduleTemplate = (function () {
 
     },
     registerHook: function (hookname, rank, callback) {
-
+      
+  
       if (typeof hookname === "string" && typeof rank === "number" && typeof callback === "function") {
 
         if (!hooks[hookname]) {
@@ -64,10 +88,11 @@ var moduleTemplate = (function () {
           hooks[hookname] = {
 
             rank: rank,
-            event: callback
+            event: callback,
+            registration: getCaller()
 
           };
-
+          
         } else {
 
           console.log("Hook " + hookname + " already defined in this module");


### PR DESCRIPTION
Allow a hook function to get the filename of the hook function that came before it. Aiming to possibly decouple hooks and modules in the future because of new opportunities opened up by #394 . This will make working with that easier as you'll be able to debug where a hook came from. 

Regardless, this is probably a useful debugging function even now.

```JavaScript

iris.modules.myModule.registerHook("hook_form_render__login", 3, function(thisHook,data){

    console.log(thisHook.previousHook);

    thisHook.pass(data);

});

```